### PR TITLE
rename qnity to opensourcemodelling

### DIFF
--- a/lifelib/libraries/economic_curves/EIOPA_smith_wilson_test/README.md
+++ b/lifelib/libraries/economic_curves/EIOPA_smith_wilson_test/README.md
@@ -12,6 +12,6 @@ The target maturities (`T_Obs`), the additional parameters (`UFR` and `alpha`) a
 ## Smith&Wilson algorithm
 
 The implementation of the SW algorithm is a slight modification to the original OSM implementation. The original implementation can be found in different languages on the OSM's GitHub repository:
--  [Python](https://github.com/qnity/insurance_python/tree/main/smith%26wilson).
--  [Matlab](https://github.com/qnity/insurance_matlab/tree/main/smith%26wilson).
--  [JavaScript](https://github.com/qnity/insurance_javascript/tree/main/smith-wilson).
+-  [Python](https://github.com/open-source-modelling/insurance_python/tree/main/smith_wilson).
+-  [Matlab](https://github.com/open-source-modelling/insurance_matlab/tree/main/smith_wilson).
+-  [JavaScript](https://github.com/open-source-modelling/insurance_javascript/tree/main/smith_wilson).

--- a/lifelib/libraries/economic_curves/bisection_alpha/README.md
+++ b/lifelib/libraries/economic_curves/bisection_alpha/README.md
@@ -57,5 +57,5 @@ the {doc}`smith_wilson` algorithm.
 They are duplicated to this repository for completeness. 
 
 If there are any inconsistencies or suggestions, raise an [issue](https://github.com/lifelib-dev/lifelib/issues),
-or contact [the original authors](https://github.com/qnity), 
+or contact [the original authors](https://github.com/open-source-modelling), 
 or start a discussion at [lifelib Discussions](https://github.com/lifelib-dev/lifelib/discussions).

--- a/lifelib/libraries/economic_curves/smith_wilson/README.md
+++ b/lifelib/libraries/economic_curves/smith_wilson/README.md
@@ -88,5 +88,5 @@ An example of this format is the monthly risk free rate published by turopean In
 Occupational Pensions Authority (<https://www.eiopa.europa.eu/tools-and-data/>).
 
 To suggest improving the code/comments etc. in this library
-contact [the original authors](https://github.com/qnity), 
+contact [the original authors](https://github.com/open-source-modelling), 
 or start a discussion at [lifelib Discussions](https://github.com/lifelib-dev/lifelib/discussions).

--- a/makedocs/source/libraries/economic_curves/index.md
+++ b/makedocs/source/libraries/economic_curves/index.md
@@ -15,8 +15,8 @@ in UK and EU countries under the Solvency 2 regime.
 
 ```{seealso}
 This library was based on 
-[insurance_python](https://github.com/qnity/insurance_python), a library in an external project, 
-the [Actuarial Algorithms](https://github.com/qnity), 
+[insurance_python](https://github.com/open-source-modelling/insurance_python), a library in an external project, 
+the [Actuarial Algorithms](https://github.com/open-source-modelling), 
 developed and maintained by Qnity Consultants and Gregor Fabjan.
 ```
 
@@ -92,20 +92,5 @@ Metropolis_Hastings
 [BIS whitepaper]: https://www.bis.org/publ/bppdf/bispap25l.pdf
 [Wiki Black&Sholes]: https://en.wikipedia.org/wiki/Black%E2%80%93Scholes_model
 [Wiki Vasicek]: https://en.wikipedia.org/wiki/Vasicek_model
-
-## Algorithms planned
-
-New suggestions for algorithms are welcome. 
-If anybody is interested in publishing an algorithm they implemented, or help with the project, 
-contact [the original authors](https://github.com/qnity), 
-or start a discussion at [lifelib Discussions](https://github.com/lifelib-dev/lifelib/discussions).
-
-
-| Algorithm              | Source  | Description                                                            |
-| ---------------------- |---------| ---------------------------------------------------------------------- |
-| Matrix on fraction     | TBD     | Heuristics for calculating transition matrices on fractions of power   |
-| G2++ with piec cons vol| TBD     | Calibration of a G2++ model with piecwise constant volatility          |
-| Carter-Lee model       | TBD     | Simple stochastic mortality model                                      |
-| Metropolis-Hastings    | TBD     | Sampling of probability distributions                                  |
 
 

--- a/makedocs/source/releases/relnotes_v0.8.0.rst
+++ b/makedocs/source/releases/relnotes_v0.8.0.rst
@@ -27,8 +27,8 @@ many of which are relevant to regulatory requirements
 in UK and EU countries under the Solvency 2 regime.
 
 This library was based on
-`insurance_python <https://github.com/qnity/insurance_python>`_, a library in an external project,
-the `Actuarial Algorithms <https://github.com/qnity>`_,
+`insurance_python <https://github.com/open-source-modelling/insurance_python>`_, a library in an external project,
+the `Actuarial Algorithms <https://github.com/open-source-modelling>`_,
 developed and maintained by Qnity Consultants and Gregor Fabjan.
 
 See :mod:`~economic_curves` and :ref:`notebooks_economic_curves` for more details.


### PR DESCRIPTION
fix a couple of broken links. Removed the "algorithms planned" section