### PR TITLE
docs: typo fix in ASL premiums note

### DIFF
--- a/makedocs/source/libraries/basiclife/BasicTermASL_ME.rst
+++ b/makedocs/source/libraries/basiclife/BasicTermASL_ME.rst
@@ -43,7 +43,7 @@ in :func:`~basiclife.BasicTermASL_ME.Pricing.model_point`.
 :func:`~basiclife.BasicTermASL_ME.Pricing.premium_pp` calculates
 premiums per 1000 sum assured per payment from
 :func:`~basiclife.BasicTermASL_ME.Base.loading_prem` and
-the present values of premiums and claims.
+the present values of claims over present value of polices in-force for premium payments.
 :func:`Pricing.premium_pp` is brought in to :mod:`~basiclife.BasicTermASL_ME.Projection`
 as :attr:`~Projection.pricing_premium_pp` and
 referenced by :func:`Projection.premium_pp`.


### PR DESCRIPTION
I guess a typo: premium from PV premium is a circular reference :)

Maybe a link to [`pv_pols_if_pay`](https://lifelib.io/libraries/generated/basiclife.BasicTermASL_ME.Base.pv_pols_if_pay.html#basiclife.BasicTermASL_ME.Base.pv_pols_if_pay) and/or [`net_premium_rate`](https://lifelib.io/_modules/basiclife/BasicTermASL_ME/Pricing.html#net_premium_rate) is good to add.