### PR TITLE
fix: add pytest-cov to test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ Homepage = "https://lifelib.io"
 [project.optional-dependencies]
 test = [
     "pytest>=7.0",
+    "pytest-cov>=4.0",
     "pytest-xdist>=3.0",
     "pandas",
     "numpy>=1.16.5",
@@ -50,6 +51,7 @@ test = [
 ]
 dev = [
     "pytest>=7.0",
+    "pytest-cov>=4.0",
     "pytest-xdist>=3.0",
     "pandas",
     "numpy>=1.16.5",


### PR DESCRIPTION
Fixes #93

This change adds `pytest-cov` to the optional test and development dependencies.

Before this change, the documented workflow

- `make init`
- `source venv_lifelib/bin/activate`
- `make test`

could fail in a fresh environment because `make test` uses coverage options, but `pytest-cov` was not installed by `make init`.

After this change, `make init` installs `pytest-cov`, and `make test` works as expected in a fresh environment.