### PR TITLE
Refactor DataFrame fillna calls to use dictionary syntax

### DIFF
--- a/lifelib/libraries/ifrs17a/ifrs17/Importers.py
+++ b/lifelib/libraries/ifrs17a/ifrs17/Importers.py
@@ -600,9 +600,9 @@ def _FormatCashflow(target: IfrsDatabase, dataSet: IDataSet):
 
     # Replace nan to '' or 0
     if 'Scenario' in dataSet.Tables['Main'].columns:
-        dataSet.Tables['Main']['Scenario'].fillna('', inplace=True)
+        dataSet.Tables['Main'].fillna({'Scenario': ''}, inplace=True)
     if 'AccidentYear' in dataSet.Tables['Cashflow'].columns:
-        dataSet.Tables['Cashflow']['AccidentYear'].fillna(0, inplace=True)
+        dataSet.Tables['Cashflow'].fillna({'AccidentYear': 0}, inplace=True)
 
     args = target.GetArgsFromMain(PartitionByReportingNodeAndPeriod, dataSet)
     args = dataclasses.replace(args, ImportFormat=ImportFormats.Cashflow)
@@ -676,7 +676,7 @@ def ParseActualsToWorkspace(dataSet: IDataSet, args: ImportArgs, target: IfrsDat
 def _FormatActual(target: IfrsDatabase, dataSet: IDataSet):
 
     if 'AccidentYear' in dataSet.Tables['Actual'].columns:
-        dataSet.Tables['Actual']['AccidentYear'].fillna(0, inplace=True)
+        dataSet.Tables['Actual'].fillna({'AccidentYear': 0}, inplace=True)
 
     args = target.GetArgsFromMain(PartitionByReportingNodeAndPeriod, dataSet)
     args = dataclasses.replace(args, ImportFormat=ImportFormats.Actual)
@@ -744,9 +744,11 @@ def _FormatSimpleValue(target: IfrsDatabase, dataSet: IDataSet):
 
     # Replace nan to '' or 0
     if 'Scenario' in dataSet.Tables['Main'].columns:
-        dataSet.Tables['Main']['Scenario'].fillna('', inplace=True)
-    for col, nul in [('AccidentYear', 0), ('AmountType', ''), ('EconomicBasis', '')]:
-        dataSet.Tables['SimpleValue'][col].fillna(nul, inplace=True)
+        dataSet.Tables['Main'].fillna({'Scenario': ''}, inplace=True)
+    dataSet.Tables['SimpleValue'].fillna(
+        {'AccidentYear': 0, 'AmountType': '', 'EconomicBasis': ''},
+        inplace=True,
+    )
 
     args = target.GetArgsFromMain(PartitionByReportingNodeAndPeriod, dataSet)
     args = dataclasses.replace(args, ImportFormat=ImportFormats.SimpleValue)
@@ -763,8 +765,9 @@ IfrsDatabase.DefineFormat(ImportFormats.SimpleValue, _FormatSimpleValue)
 
 def _FormatOpening(target: IfrsDatabase, dataSet: IDataSet):
 
-    dataSet.Tables['Opening']['AccidentYear'].fillna(0, inplace=True)
-    dataSet.Tables['Opening']['AmountType'].fillna('', inplace=True)
+    dataSet.Tables['Opening'].fillna(
+        {'AccidentYear': 0, 'AmountType': ''}, inplace=True
+    )
 
     args = target.GetArgsFromMain(PartitionByReportingNodeAndPeriod, dataSet)
     args = dataclasses.replace(args, ImportFormat=ImportFormats.Opening)


### PR DESCRIPTION
## Summary
Refactored multiple `fillna()` calls in the IFRS17 importers to use pandas' dictionary-based syntax instead of chaining column selection with `fillna()`. This improves code readability and follows pandas best practices.

## Key Changes
- **_FormatCashflow()**: Converted single-column `fillna()` calls to dictionary-based syntax for 'Scenario' and 'AccidentYear' columns
- **_FormatActual()**: Updated 'AccidentYear' column fillna to use dictionary syntax
- **_FormatSimpleValue()**: Refactored loop-based fillna calls into a single dictionary-based call for 'AccidentYear', 'AmountType', and 'EconomicBasis' columns
- **_FormatOpening()**: Consolidated two separate fillna calls into a single dictionary-based call for 'AccidentYear' and 'AmountType' columns

## Implementation Details
- Changed from `dataSet.Tables['Table']['Column'].fillna(value, inplace=True)` to `dataSet.Tables['Table'].fillna({'Column': value}, inplace=True)`
- Improved code organization by grouping related fillna operations together
- Maintained identical functionality while enhancing code clarity and maintainability

https://claude.ai/code/session_01EpSNDMUCmAwjsKFSpBeAnx