### PR TITLE
Fix string column detection in replace_nan function

### DIFF
--- a/lifelib/libraries/ifrs17a/ifrs17/Database.py
+++ b/lifelib/libraries/ifrs17a/ifrs17/Database.py
@@ -32,7 +32,7 @@ def remove_duplicates(input_list: list) -> list:
 
 def replace_nan(df):
     float_cols = df.select_dtypes(include=['float64']).columns
-    str_cols = df.select_dtypes(include=['object']).columns
+    str_cols = df.select_dtypes(include=['object', 'str']).columns
 
     df.loc[:, float_cols] = df.loc[:, float_cols].fillna(0)
     df.loc[:, str_cols] = df.loc[:, str_cols].fillna('')

--- a/lifelib/libraries/ifrs17a/ifrs17/Database.py
+++ b/lifelib/libraries/ifrs17a/ifrs17/Database.py
@@ -32,7 +32,10 @@ def remove_duplicates(input_list: list) -> list:
 
 def replace_nan(df):
     float_cols = df.select_dtypes(include=['float64']).columns
-    str_cols = df.select_dtypes(include=['object', 'str']).columns
+    try:
+        str_cols = df.select_dtypes(include=['object', 'str']).columns
+    except TypeError:
+        str_cols = df.select_dtypes(include=['object']).columns
 
     df.loc[:, float_cols] = df.loc[:, float_cols].fillna(0)
     df.loc[:, str_cols] = df.loc[:, str_cols].fillna('')


### PR DESCRIPTION
## Summary
Updated the `replace_nan` function in the Database module to properly detect string-type columns by including both 'object' and 'str' dtypes when selecting columns for NaN replacement.

## Key Changes
- Modified the `select_dtypes()` call in `replace_nan()` to include both `'object'` and `'str'` dtype specifications when identifying string columns
- This ensures that string columns are correctly identified and filled with empty strings instead of NaN values, regardless of how pandas represents the string dtype

## Implementation Details
The change addresses a potential issue where string columns might not be properly detected if they use the newer pandas `'str'` dtype in addition to the traditional `'object'` dtype. By including both dtype specifications, the function now handles both representations consistently.

https://claude.ai/code/session_0192A74bNaGXv8yVG7QeJUuT