### PR TITLE
ENH: Pre-compute last mortality age in TradLife_A

### DIFF
--- a/lifelib/libraries/annuallife/TradLife_A/Assumptions/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Assumptions/__init__.py
@@ -182,6 +182,18 @@ def mort_array_index():
     )
 
 
+def last_mort_age():
+    """Last mortality age (first age where mortality reaches 1) per policy."""
+
+    last_ages = input_data.mort_table_last_ages()
+    keys = pd.MultiIndex.from_arrays(
+        [mort_table_index(), input_data.policy_data()['Sex']]
+    )
+    result = pd.Series(last_ages.reindex(keys).values,
+                       index=input_data.policy_data().index)
+    return pandas_to_array(result)
+
+
 def asmp_tables():
     return pandas_to_array(input_data.assumption_tables())
 

--- a/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
@@ -474,7 +474,7 @@ def sum_assured(t):
 
 
 def proj_len():
-    return min(last_age() - pol.issue_age()[idx], 
+    return min(last_mort_age() - pol.issue_age()[idx],
                pol.policy_term()[idx])
 
 
@@ -588,13 +588,9 @@ def surr_charge(t):
     return pol.init_surr_charge()[idx] * max((min(m, 10) - t) / min(m, 10), 0)
 
 
-def last_age():
-    """Age at which mortality becomes 1"""
-    x = 0
-    while True:
-        if mort_rate(x) == 1:
-            return x
-        x += 1
+def last_mort_age():
+    """Age at which mortality becomes 1 for this policy"""
+    return asmp.last_mort_age()[idx]
 
 
 def inflation_factor(t):

--- a/lifelib/libraries/annuallife/TradLife_A/InputData/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/InputData/__init__.py
@@ -133,6 +133,16 @@ def mortality_tables():
     return df
 
 
+def mort_table_last_ages():
+    """First Age (the row index) at which mortality reaches 1, per column.
+
+    Returns a Series indexed by ``mortality_tables().columns``
+    (a MultiIndex of (MortTable, Sex)) with the Age value from the row index.
+    """
+    df = mortality_tables()
+    return (df == 1).idxmax()
+
+
 def assumption_tables():
 
     # wb = input_workbook()


### PR DESCRIPTION
## Summary

- Replaces the per-policy `while`-loop in `BaseProj.last_age` (which called the `mort_rate(x)` cell once per age until it found 1) with a vectorized lookup computed once per `(MortTable, Sex)` column of the mortality tables.
- Renames `BaseProj.last_age` to `last_mort_age` and updates the sole reference in `proj_len`.

## Why

`BaseProj.last_age` is invoked once per policy via `proj_len`. Because the mortality tables are static input data, the "first age where mortality hits 1" can be computed once per table column and then mapped onto policies through the existing `(mort_table_index, Sex)` join used by `Assumptions.mort_array_index`. This removes a Python loop from the per-policy hot path.

## Changes

- `InputData.mort_table_last_ages` — new cell. `(df == 1).idxmax()` over `mortality_tables()` columns, returns a `Series` indexed by the table's `(MortTable, Sex)` `MultiIndex`.
- `Assumptions.last_mort_age` — new cell. Reindexes `mort_table_last_ages` by per-policy `(mort_table_index(), policy_data()['Sex'])` keys; passes through `pandas_to_array` like its neighbors.
- `BaseProj.last_age` → `BaseProj.last_mort_age` — body reduced to `asmp.last_mort_age()[idx]`.
- `BaseProj.proj_len` — reference updated.

The semantics are identical: the new path returns the same first-age-where-mortality-equals-1 value the loop did, just computed up-front and cached.

## Test plan

- [x] `pytest lifelib/tests/libraries/test_tradlife_a.py -v` — all 3 parameterized cases pass; `TradLife_A.pv_net_cf(0)` still matches `simplelife.PV_NetCashflow(0)` to `rel_tol=1e-9` for policies 1, 101, 201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)