### PR TITLE
DOC: Reflect last_mort_age refactor in TradLife_A API reference

### DIFF
--- a/makedocs/source/libraries/annuallife/Assumptions.rst
+++ b/makedocs/source/libraries/annuallife/Assumptions.rst
@@ -24,6 +24,7 @@ Formulas
    ~mortality_tables
    ~mort_table_index
    ~mort_array_index
+   ~last_mort_age
    ~asmp_tables
    ~mort_factor_index
    ~lapse_rate_index
@@ -62,6 +63,8 @@ Cells Descriptions
 .. autofunction:: mort_table_index
 
 .. autofunction:: mort_array_index
+
+.. autofunction:: last_mort_age
 
 .. autofunction:: asmp_tables
 

--- a/makedocs/source/libraries/annuallife/BaseProj.rst
+++ b/makedocs/source/libraries/annuallife/BaseProj.rst
@@ -94,7 +94,7 @@ Formulas
    ~net_prem_rate
    ~reserve_nlp_rate
    ~surr_charge
-   ~last_age
+   ~last_mort_age
    ~inflation_factor
    ~disc_rate_mth
 
@@ -272,7 +272,7 @@ Cells Descriptions
 
 .. autofunction:: surr_charge
 
-.. autofunction:: last_age
+.. autofunction:: last_mort_age
 
 .. autofunction:: inflation_factor
 

--- a/makedocs/source/libraries/annuallife/InputData.rst
+++ b/makedocs/source/libraries/annuallife/InputData.rst
@@ -12,6 +12,7 @@ Formulas
    ~input_workbook
    ~policy_data
    ~mortality_tables
+   ~mort_table_last_ages
    ~assumption_tables
    ~scenarios
    ~discount_rate
@@ -32,6 +33,8 @@ Cells Descriptions
 .. autofunction:: policy_data
 
 .. autofunction:: mortality_tables
+
+.. autofunction:: mort_table_last_ages
 
 .. autofunction:: assumption_tables
 


### PR DESCRIPTION
## Summary

- Mirror the cell-level changes from a318d86 (*ENH: Pre-compute last mortality age in TradLife_A*) in the Sphinx API pages under `makedocs/source/libraries/annuallife/` so the rendered reference matches the model.
- `InputData.rst`: add `mort_table_last_ages` to the autosummary and cells-description list.
- `Assumptions.rst`: add `last_mort_age`.
- `BaseProj.rst`: rename `last_age` -> `last_mort_age`.

Without these updates, the rendered docs would still document the removed `BaseProj.last_age` cell and would be missing the two new cells (`mort_table_last_ages`, `last_mort_age`).

## Test plan

- [x] `python -m sphinx -b html makedocs/source makedocs/build` completes without warnings about my changes (the only failures are pre-existing nbsphinx notebook execution issues unrelated to this PR).
- [x] Rendered HTML confirmed:
  - `BaseProj.html` shows `last_mort_age` and no longer references `last_age`.
  - `Assumptions.html` includes a `last_mort_age` entry.
  - `InputData.html` includes a `mort_table_last_ages` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)