### PR TITLE
ENH: Rename exps_comm_* commission cells to commissions_*

### DIFF
--- a/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
@@ -24,7 +24,7 @@ Space, and it contains Cells for cashflow projection.
 
 ``Exps``:
     Cells whose names start with ``Exps`` represents expense cashflows.
-    For example, ``exps_comm_ren`` means the renewal commission cashflow.
+    For example, ``exps_maint`` means the maintenance expense cashflow.
 
 ``Claims``:
     Cells whose names start with ``Claims`` represent benefit cashflows.
@@ -140,19 +140,19 @@ def exps_acq_total(t):
     return commissions(t) + exps_acq(t)
 
 
-def exps_comm_init(t):
+def commissions_init(t):
     """Initial commissions"""
-    return exps_comm_init_pp(t) * pols_if_beg1(t)
+    return commissions_init_pp(t) * pols_if_beg1(t)
 
 
-def exps_comm_ren(t):
+def commissions_ren(t):
     """Renewal commissions"""
-    return exps_comm_ren_pp(t) * pols_if_beg1(t)
+    return commissions_ren_pp(t) * pols_if_beg1(t)
 
 
 def commissions(t):
     """Commissions Total"""
-    return exps_comm_init(t) + exps_comm_ren(t)
+    return commissions_init(t) + commissions_ren(t)
 
 
 def exps_maint(t):
@@ -172,8 +172,8 @@ def exps_other(t):
 
 def expenses(t):
     """Total expenses"""
-    return (exps_comm_init(t)
-            + exps_comm_ren(t)
+    return (commissions_init(t)
+            + commissions_ren(t)
             + exps_acq(t)
             + exps_maint(t)
             + exps_other(t))
@@ -402,7 +402,7 @@ def expense_acq_pp(t):
         return 0
 
 
-def exps_comm_init_pp(t):
+def commissions_init_pp(t):
     """Initial commission per policy at time t"""
     if t == 0:
         return premium_pp(t) * asmp.comm_init_prem()[idx] * (1 + asmp.cnsmp_tax())
@@ -410,7 +410,7 @@ def exps_comm_init_pp(t):
         return 0
 
 
-def exps_comm_ren_pp(t):
+def commissions_ren_pp(t):
     """Renewal commission per policy at time t"""
     if t == 0:
         return 0

--- a/makedocs/source/libraries/annuallife/BaseProj.rst
+++ b/makedocs/source/libraries/annuallife/BaseProj.rst
@@ -25,8 +25,8 @@ Formulas
    ~change_rsrv
    ~exps_acq
    ~exps_acq_total
-   ~exps_comm_init
-   ~exps_comm_ren
+   ~commissions_init
+   ~commissions_ren
    ~commissions
    ~exps_maint
    ~exps_maint_total
@@ -72,8 +72,8 @@ Formulas
    ~claims_surg_pp
    ~claims_surr_pp
    ~expense_acq_pp
-   ~exps_comm_init_pp
-   ~exps_comm_ren_pp
+   ~commissions_init_pp
+   ~commissions_ren_pp
    ~expense_maint_pp
    ~exps_other_pp
    ~invst_income_pp
@@ -134,9 +134,9 @@ Cells Descriptions
 
 .. autofunction:: exps_acq_total
 
-.. autofunction:: exps_comm_init
+.. autofunction:: commissions_init
 
-.. autofunction:: exps_comm_ren
+.. autofunction:: commissions_ren
 
 .. autofunction:: commissions
 
@@ -228,9 +228,9 @@ Cells Descriptions
 
 .. autofunction:: expense_acq_pp
 
-.. autofunction:: exps_comm_init_pp
+.. autofunction:: commissions_init_pp
 
-.. autofunction:: exps_comm_ren_pp
+.. autofunction:: commissions_ren_pp
 
 .. autofunction:: expense_maint_pp
 


### PR DESCRIPTION
## Summary

- Continues the [`3f738b3`](https://github.com/lifelib-dev/lifelib/commit/3f738b3) cell-naming standardization in `TradLife_A.BaseProj` by bringing the commission components under the existing `commissions(t)` umbrella, mirroring the `claims_*` / `claims_*_pp` pattern.
- Renames four cells: `exps_comm_init` → `commissions_init`, `exps_comm_ren` → `commissions_ren`, `exps_comm_init_pp` → `commissions_init_pp`, `exps_comm_ren_pp` → `commissions_ren_pp`. Updates call sites in `commissions` / `expenses` and the autosummary/autofunction entries in `BaseProj.rst`.
- Updates the `Exps` docstring example to `exps_maint` (no `exps_comm_*` cell remains as a representative).

## Notes for reviewers

- No test files referenced the renamed cells, so no test changes were required.
- `data.pickle` and the `_data/` directory were intentionally untouched — modelx reads cell definitions from `__init__.py`, and the prior standardization commit followed the same approach.
- The output cell list inside `tradlife_a-space-overview.ipynb` is left to regenerate naturally on the next notebook execution.

## Test plan

- [x] `pytest lifelib/tests/libraries/test_tradlife_a.py` — 3/3 pass
- [x] Smoke import via modelx: all four new cell names resolve, all four old names absent
- [x] `Projection[1]` exercise: `commissions_init(0) = 588.47`, `commissions_ren(1) = 135.31`, `commissions_init_pp(0) = 588.47`, `commissions_ren_pp(1) = 147.12`, with `commissions(0) = commissions_init(0)` as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)