### PR TITLE
Clean up commented-out legacy code in TradLife_A module

### DIFF
--- a/lifelib/libraries/annuallife/TradLife_A/Assumptions/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Assumptions/__init__.py
@@ -71,88 +71,56 @@ def mort_rate(x):
 
 def cnsmp_tax():
     """Consumption tax rate"""
-    # return asmp_lookup("CnsmpTax")
-    # return pandas_to_array(map_to_policies(input_data.assumption('CnsmpTax')))
     return input_data.const_params()['CnsmpTax']
 
 
 def comm_init_prem():
     """Initial commission per premium"""
-    # result = _space.asmp_lookup.match("CommInitPrem", prod(), polt(), gen()).value
-
-    # if result is not None:
-    #     return result
-    # else:
-    #     raise ValueError('comm_init_prem not found')
-
     return pandas_to_array(map_to_policies(input_data.assumption('CommInitPrem')))
 
 
 def comm_ren_prem():
     """Renewal commission per premium"""
-    # result = _space.asmp_lookup.match("CommRenPrem", prod(), polt(), gen()).value
-
-    # if result is not None:
-    #     return  result
-    # else:
-    #     raise ValueError('comm_ren_prem not found')
-
     return pandas_to_array(map_to_policies(input_data.assumption('CommRenPrem')))
 
 
 def comm_ren_term():
     """Renewal commission term"""
-    # result = _space.asmp_lookup.match("CommRenTerm", prod(), polt(), gen()).value
-
-    # if result is not None:
-    #     return result
-    # else:
-    #     raise ValueError('comm_ren_term not found')
-
     return pandas_to_array(map_to_policies(input_data.assumption('CommRenTerm')))
 
 
 def exps_acq_ann_prem():
     """Acquisition expense per annualized premium"""
-    # return _space.asmp_lookup.match("ExpsAcqAnnPrem", prod(), polt(), gen()).value
-
     return pandas_to_array(map_to_policies(input_data.assumption('ExpsAcqAnnPrem')))
 
 
 def exps_acq_pol():
     """Acquisition expense per policy"""
-    # return _space.asmp_lookup.match("ExpsAcqPol", prod(), polt(), gen()).value
     return pandas_to_array(map_to_policies(input_data.assumption('ExpsAcqPol')))
 
 
 def exps_acq_sa():
     """Acquisition expense per sum assured"""
-    # return _space.asmp_lookup.match("ExpsAcqSA", prod(), polt(), gen()).value
     return pandas_to_array(map_to_policies(input_data.assumption('ExpsAcqSA')))
 
 
 def exps_maint_ann_prem():
     """Maintenance expense per annualized premium"""
-    # return _space.asmp_lookup.match("ExpsMaintPrem", prod(), polt(), gen()).value
     return pandas_to_array(map_to_policies(input_data.assumption('ExpsMaintPrem')))
 
 
 def exps_maint_pol():
     """Maintenance expense per policy"""
-    # return _space.asmp_lookup.match("ExpsMaintPol", prod(), polt(), gen()).value
     return pandas_to_array(map_to_policies(input_data.assumption('ExpsMaintPol')))
 
 
 def exps_maint_sa():
     """Maintenance expense per sum assured"""
-    # return _space.asmp_lookup.match("ExpsMaintSA", prod(), polt(), gen()).value
     return pandas_to_array(map_to_policies(input_data.assumption('ExpsMaintSA')))
 
 
 def inflation_rate():
     """Inflation rate"""
-    # return asmp_lookup("InflRate")
-    # return pandas_to_array(map_to_policies(input_data.assumption('InflRate')))
     return input_data.const_params()['InflRate']
 
 

--- a/lifelib/libraries/annuallife/TradLife_A/Assumptions/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Assumptions/__init__.py
@@ -128,15 +128,10 @@ def mortality_tables():
     """Mortality Table"""
 
     tables = input_data.mortality_tables()
-    # return tables.to_numpy() if return_array else tables
     return pandas_to_array(tables)
 
 
 def mort_table_index():
-    # s = input_data.assumption('BaseMort')
-
-    # return s.reindex(pd.MultiIndex.from_frame(
-    #     input_data.policy_data()[s.index.names]))
     return map_to_policies(input_data.assumption('BaseMort'))
 
 

--- a/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
@@ -537,19 +537,13 @@ def net_prem_rate(basis):
     """Net Premium Rate"""
 
     gamma2 = pol.load_maint_sa2()[idx]
-    # comf = life_table[sex(), int_rate(basis), table_id(basis)]
-
 
     comf = comm_table[
         pol.sex()[idx],
         pol.int_rate(basis)[idx],
         pol.table_id(basis)[idx]]
 
-
-    # x, n, m = issue_age(), policy_term(), prem_term()
-
     x, n, m = pol.issue_age()[idx], pol.policy_term()[idx], pol.prem_term()[idx]
-
 
     if pol.product()[idx] == ProductID.TERM or pol.product()[idx] == ProductID.WL:
         return (comf.Axn(x, n) + gamma2 * comf.AnnDuenx(x, n-m, 1, m)) / comf.AnnDuenx(x, n)
@@ -566,12 +560,10 @@ def reserve_nlp_rate(basis, t):
 
     gamma2 = pol.load_maint_sa2()[idx]
 
-    # lt = life_table[sex(), int_rate(basis), table_id(basis)]
     comf = comm_table[
         pol.sex()[idx],
         pol.int_rate(basis)[idx],
         pol.table_id(basis)[idx]]
-
 
     x, n, m = pol.issue_age()[idx], pol.policy_term()[idx], pol.prem_term()[idx]
 

--- a/lifelib/libraries/annuallife/TradLife_A/InputData/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/InputData/__init__.py
@@ -82,17 +82,6 @@ def input_workbook():
 
 def policy_data():
 
-    # wb = input_workbook()
-
-    # sheet_name, cell_range = next(wb.defined_names["PolicyData"].destinations)
-    # ws = wb[sheet_name]
-
-    # rows = list(ws[cell_range.replace('$', '')])
-    # headers = [cell.value for cell in rows[0]]
-    # data = [[cell.value for cell in row] for row in rows[1:]]
-
-    # return pd.DataFrame(data, columns=headers).set_index(headers[0])
-
     return get_named_range_as_df('PolicyData', index_len=1)
 
 
@@ -145,17 +134,6 @@ def mort_table_last_ages():
 
 def assumption_tables():
 
-    # wb = input_workbook()
-
-    # sheet_name, cell_range = next(wb.defined_names["AsmpByDuration"].destinations)
-    # ws = wb[sheet_name]
-
-    # rows = list(ws[cell_range.replace('$', '')])
-    # headers = [cell.value for cell in rows[0]]
-    # data = [[cell.value for cell in row] for row in rows[1:]]
-
-    # return pd.DataFrame(data, columns=headers).set_index(headers[0])
-
     return get_named_range_as_df('AsmpByDuration', index_len=1)
 
 
@@ -182,17 +160,6 @@ def get_named_range_as_df(name, index_len=0):
 _is_cached = False
 
 def scenarios():
-
-    # wb = input_workbook()
-
-    # sheet_name, cell_range = next(wb.defined_names["PolicyData"].destinations)
-    # ws = wb[sheet_name]
-
-    # rows = list(ws[cell_range.replace('$', '')])
-    # headers = [cell.value for cell in rows[0]]
-    # data = [[cell.value for cell in row] for row in rows[1:]]
-
-    # return pd.DataFrame(data, columns=headers).set_index(headers[0])
 
     return get_named_range_as_df('Scenarios', index_len=2)
 

--- a/lifelib/libraries/annuallife/TradLife_A/PolicyAttrs/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/PolicyAttrs/__init__.py
@@ -71,12 +71,6 @@ def gross_prem_table():
 def init_surr_charge():
     """Initial Surrender Charge Rate"""
 
-    # param1 = _space.SpecLookup.match("SurrChargeParam1", product(), policy_type(), gen()).value
-    # param2 = _space.SpecLookup.match("SurrChargeParam2", product(), policy_type(), gen()).value
-
-    # if param1 is None or param2 is None:
-    #     raise ValueError('SurrChargeParam not found')
-
     param1 = surr_charge_param1()
     param2 = surr_charge_param2()
 
@@ -114,13 +108,6 @@ def load_maint_prem():
 def load_maint_prem_waiver_prem():
     """Maintenance Loading per Gross Premium for Premium Waiver"""
 
-    # if prem_term() < 5:
-    #     return 0.0005
-    # elif prem_term() < 10:
-    #     return 0.001
-    # else:
-    #     return 0.002
-
     table = input_data.prem_waiver_cost()
 
     bins = [-np.inf] + list(table.keys())[:-1] + [np.inf]
@@ -155,20 +142,6 @@ def reserve_rate():
 
 def table_id(basis):
     """Mortality Table ID"""
-
-    # if RateBasis == 'PREM':
-    #     basis = "MortTablePrem"
-    # elif RateBasis == 'VAL':
-    #     basis = "MortTableVal"
-    # else:
-    #     raise ValueError('invalid RateBasis')
-
-    # result = _space.SpecLookup.match(basis, product(), policy_type(), gen()).value
-
-    # if result is not None:
-    #     return result
-    # else:
-    #     raise ValueError('invalid RateBais')
 
     col = {
         RateBasisID.PREM: 'MortTablePrem',

--- a/lifelib/libraries/annuallife/TradLife_A/PolicyAttrs/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/PolicyAttrs/__init__.py
@@ -118,7 +118,7 @@ def load_maint_prem_waiver_prem():
          bins=bins,
          labels=vals,
          right=False,        # left-closed: [x, y)
-     )) #.astype(float)
+     ))
 
 
 def load_maint_sa():
@@ -157,13 +157,6 @@ def uern_prem_rate():
 
 
 def product():
-    # return getattr(ProductID, 'TERM')
-
-    # prod_str_to_int = {
-    #     'TERM': ProductID.TERM,
-    #     'WL': ProductID.WL,
-    #     'ENDW': ProductID.ENDW
-    #     }
     return pandas_to_array(input_data.policy_data()['Product'].map(lambda s: getattr(ProductID, s)))
 
 
@@ -205,25 +198,21 @@ def sum_assured():
 
 
 def load_acq_sa_param1():
-    # return input_data.product_spec('LoadAcqSAParam2')
     return pandas_to_array(
         map_to_policies(input_data.product_spec('LoadAcqSAParam1')))
 
 
 def load_acq_sa_param2():
-    # return input_data.product_spec('LoadAcqSAParam2')
     return pandas_to_array(
         map_to_policies(input_data.product_spec('LoadAcqSAParam2')))
 
 
 def load_maint_prem_param1():
-    # return input_data.product_spec('LoadAcqSAParam2')
     return pandas_to_array(
         map_to_policies(input_data.product_spec('LoadMaintPremParam1')))
 
 
 def load_maint_prem_param2():
-    # return input_data.product_spec('LoadAcqSAParam2')
     return pandas_to_array(
         map_to_policies(input_data.product_spec('LoadMaintPremParam2')))
 


### PR DESCRIPTION
## Summary
This PR removes extensive commented-out legacy code from the TradLife_A module, improving code readability and maintainability. The commented code appears to be from an older implementation approach that has been superseded by the current implementation.

## Key Changes
- **Assumptions/__init__.py**: Removed commented-out alternative implementations in 11 functions (`cnsmp_tax`, `comm_init_prem`, `comm_ren_prem`, `comm_ren_term`, `exps_acq_ann_prem`, `exps_acq_pol`, `exps_acq_sa`, `exps_maint_ann_prem`, `exps_maint_pol`, `exps_maint_sa`, `inflation_rate`)
- **PolicyAttrs/__init__.py**: Removed commented-out legacy code from 2 functions (`init_surr_charge`, `load_maint_prem_waiver_prem`, `table_id`)
- **BaseProj/__init__.py**: Removed commented-out variable assignments and alternative implementations in 2 functions (`net_prem_rate`, `reserve_nlp_rate`)

## Implementation Details
- All active code paths remain unchanged; only commented-out code was removed
- The cleanup reveals the current implementation strategy relies on:
  - `input_data` module for parameter lookups
  - `map_to_policies` and `pandas_to_array` for data transformation
  - Direct dictionary access for constant parameters
- No functional changes to the module's behavior

https://claude.ai/code/session_01AeHBoK7HcRPKpLKeFDBxEK