### PR TITLE
Remove unused mort_rate function from TradLife_A assumptions

### DIFF
--- a/lifelib/libraries/annuallife/TradLife_A/Assumptions/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Assumptions/__init__.py
@@ -60,15 +60,6 @@ _spaces = [
 # ---------------------------------------------------------------------------
 # Cells
 
-def mort_rate(x):
-    """Bae mortality rate"""
-
-    return _space.asmp_lookup
-
-    table_id = _space.asmp_lookup.match("BaseMort", prod(), polt(), gen()).value
-    return mortality_tables[table_id, sex(), x]
-
-
 def cnsmp_tax():
     """Consumption tax rate"""
     return input_data.const_params()['CnsmpTax']


### PR DESCRIPTION
## Summary
Removed an unused and incomplete `mort_rate()` function from the TradLife_A assumptions module.

## Key Changes
- Deleted the `mort_rate(x)` function that was defined but never called
- The function contained incomplete/broken implementation with unreachable code (return statement followed by additional logic)
- This cleanup removes technical debt and clarifies the codebase

## Details
The removed function appeared to be a work-in-progress implementation for retrieving base mortality rates. It had a premature return statement that made the subsequent lookup logic unreachable, indicating it was either abandoned or superseded by other mortality rate handling logic elsewhere in the codebase.

https://claude.ai/code/session_014WgZ5Bn6qCSWMMaXbdtDsq