### PR TITLE
Improve documentation for TradLife_A model spaces

### DIFF
--- a/lifelib/libraries/annuallife/TradLife_A/Assumptions/AsmpID/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Assumptions/AsmpID/__init__.py
@@ -3,7 +3,30 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
-"""TODO: Update enum names. split table by type"""
+"""Assumption table identifiers.
+
+Integer codes identifying columns of the ``AsmpByDuration`` table
+(loaded by :func:`~annuallife.TradLife_A.InputData.assumption_tables`).
+Each member corresponds to one duration-based assumption series:
+
+* ``MortAsmp1``, ``MortAsmp2`` - mortality-factor tables, picked up by
+  :func:`~annuallife.TradLife_A.Assumptions.mort_factor_index`.
+* ``Morb1`` ... ``Morb5`` - morbidity-factor tables (reserved for
+  benefit categories not currently exercised by the model).
+* ``LapseRate1`` - lapse-rate table, picked up by
+  :func:`~annuallife.TradLife_A.Assumptions.lapse_rate_index`.
+
+The numeric values reflect the column position in
+``AsmpByDuration``; consumers should refer to the names rather than the
+numbers.
+
+.. todo::
+
+   Split the combined duration table into per-type tables so that
+   morbidity, mortality factor and lapse rates each live in dedicated
+   ranges with self-explanatory member names.
+
+"""
 
 from modelx.serialize.jsonvalues import *
 

--- a/lifelib/libraries/annuallife/TradLife_A/Assumptions/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Assumptions/__init__.py
@@ -5,41 +5,43 @@
 
 """Assumption input and calculations for individual policies.
 
-This Space is a child Space of :mod:`~simplelife.model.Projection`,
-and it holds assumption parameters and rates used
-by the :mod:`~simplelife.model.Projection` Space.
+This Space holds assumption parameters and rates used by
+:mod:`~annuallife.TradLife_A.Projection` and its base spaces.
 
-.. figure:: /images/projects/simplelife/model/Assumptions/diagram1.png
-
-.. rubric:: Parameters
-
-Since :mod:`~simplelife.model.Projection` is parameterized with
-:attr:`idx` and :attr:`scen_id`, this Space is also
-parameterized as a child space of :mod:`~simplelife.model.Projection`.
-For example, ``simplelife.Projection[1].Assumptions.exps_maint_sa()``
-represents the expense maintenance per sum assured for Policy 1.
-
-Attributes:
-    idx(:obj:`int`): Policy ID
-    scen_id(:obj:`int`, optional): Scenario ID, defaults to 1.
+Most cells in this Space return per-policy NumPy arrays whose layout
+matches the rows of
+:func:`~annuallife.TradLife_A.InputData.policy_data`, so callers index
+into them with the integer policy index ``idx``. A few cells, such as
+:func:`asmp_tables` and :func:`mortality_tables`, return tables shared
+across all policies.
 
 .. rubric:: References
 
 Attributes:
-    AssumptionTables: `ExcelRange`_ object holding data read from the
-        Excel range *AssumptionTable* in *input.xlsx*.
+    input_data: Alias for :mod:`~annuallife.TradLife_A.InputData`.
+        Per-policy assumptions are read from the ``AssumptionTable``
+        range in *input.xlsx* via
+        :func:`~annuallife.TradLife_A.InputData.assumption`,
+        and mortality / lapse tables from
+        :func:`~annuallife.TradLife_A.InputData.assumption_tables` and
+        :func:`~annuallife.TradLife_A.InputData.mortality_tables`.
 
-    MortalityTable: `ExcelRange`_ object holding mortality tables.
-        The data is read from *mortality_tables* range in *input.xlsx*.
+    return_array(:obj:`bool`): When ``True`` (the default), helper
+        functions inherited from
+        :mod:`~annuallife.TradLife_A.Utilities` return NumPy arrays
+        instead of pandas objects.
 
-    prod: Alias for :func:`simplelife.Projection.Policy.product`
-    polt: Alias for :func:`simplelife.Projection.Policy.policy_type`
-    gen: Alias for :func:`simplelife.Projection.Policy.gen`
-    sex: Alias for :func:`simplelife.Projection.Policy.sex`
-    asmp_lookup: Alias for :func:`simplelife.input_data.asmp_lookup`
+.. rubric:: Inherited helpers
 
-.. _ExcelRange:
-   https://docs.modelx.io/en/latest/reference/dataclient.html#excelrange
+Inherited from :mod:`~annuallife.TradLife_A.Utilities`:
+
+* :func:`~annuallife.TradLife_A.Utilities.pandas_to_array`
+* :func:`~annuallife.TradLife_A.Utilities.map_to_policies`
+
+.. rubric:: Child spaces
+
+* :mod:`~annuallife.TradLife_A.Assumptions.AsmpID`: Enum-style codes
+  identifying entries in the ``AsmpByDuration`` table.
 
 """
 
@@ -61,7 +63,13 @@ _spaces = [
 # Cells
 
 def mort_rate(x):
-    """Bae mortality rate"""
+    """Base mortality rate at age ``x``.
+
+    Stub kept for compatibility with the legacy :mod:`simplelife` API.
+    The annual model resolves base mortality rates through
+    :func:`~annuallife.TradLife_A.BaseProj.mort_rate`, which indexes
+    :func:`mortality_tables` using :func:`mort_array_index`.
+    """
 
     return _space.asmp_lookup
 
@@ -125,17 +133,34 @@ def inflation_rate():
 
 
 def mortality_tables():
-    """Mortality Table"""
+    """Mortality tables read from *input.xlsx*.
+
+    Returns the full mortality-table block from the ``MortalityTables``
+    range as a 2-D NumPy array (when ``return_array`` is ``True``),
+    where rows are indexed by age and columns by ``(MortTable, Sex)``.
+    """
 
     tables = input_data.mortality_tables()
     return pandas_to_array(tables)
 
 
 def mort_table_index():
+    """Per-policy mortality table identifier.
+
+    Maps the ``BaseMort`` assumption keyed by the model point lookup
+    (product, policy type, gen) to each row of
+    :func:`~annuallife.TradLife_A.InputData.policy_data`.
+    """
     return map_to_policies(input_data.assumption('BaseMort'))
 
 
 def mort_array_index():
+    """Per-policy column index into :func:`mortality_tables`.
+
+    Returns a 1-D integer array of column positions in
+    :func:`~annuallife.TradLife_A.InputData.mortality_tables` for each
+    policy's ``(mort_table_index, sex)`` pair.
+    """
 
     columns = input_data.mortality_tables().columns
 
@@ -146,7 +171,7 @@ def mort_array_index():
 
 
 def last_mort_age():
-    """Last mortality age (first age where mortality reaches 1) per policy."""
+    """Last mortality age per policy (first age where mortality reaches 1)."""
 
     last_ages = input_data.mort_table_last_ages()
     keys = pd.MultiIndex.from_arrays(
@@ -158,10 +183,24 @@ def last_mort_age():
 
 
 def asmp_tables():
+    """Assumption tables by duration.
+
+    Returns the ``AsmpByDuration`` range from *input.xlsx* as a 2-D
+    NumPy array indexed by duration (rows) and assumption ID (columns).
+    Used by :func:`~annuallife.TradLife_A.BaseProj.mort_factor` and
+    :func:`~annuallife.TradLife_A.BaseProj.lapse_rate` together with
+    :func:`mort_factor_index` and :func:`lapse_rate_index`.
+    """
     return pandas_to_array(input_data.assumption_tables())
 
 
 def mort_factor_index():
+    """Per-policy column index into :func:`asmp_tables` for mortality factors.
+
+    Resolves each policy's ``MortFactor`` assumption (referencing an
+    :mod:`~annuallife.TradLife_A.Assumptions.AsmpID`) to its column
+    position in the ``AsmpByDuration`` table.
+    """
 
 
     key_to_idx = {getattr(AsmpID, v): i for i, v in enumerate(input_data.assumption_tables().columns)}
@@ -172,6 +211,12 @@ def mort_factor_index():
 
 
 def lapse_rate_index():
+    """Per-policy column index into :func:`asmp_tables` for lapse rates.
+
+    Resolves each policy's ``Surrender`` assumption (referencing an
+    :mod:`~annuallife.TradLife_A.Assumptions.AsmpID`) to its column
+    position in the ``AsmpByDuration`` table.
+    """
 
 
     key_to_idx = {getattr(AsmpID, v): i for i, v in enumerate(input_data.assumption_tables().columns)}
@@ -182,6 +227,7 @@ def lapse_rate_index():
 
 
 def asmp_table_len():
+    """Number of rows (durations) in :func:`asmp_tables`."""
     return len(asmp_tables())
 
 

--- a/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
@@ -3,33 +3,44 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
-"""Base Space for the :mod:`~simplelife.model.Projection` Space.
+"""Base Space for the :mod:`~annuallife.TradLife_A.Projection` Space.
 
-This Space serves as a base Space for :mod:`~simplelife.model.Projection`
-Space, and it contains Cells for cashflow projection.
+This Space serves as a base Space for
+:mod:`~annuallife.TradLife_A.Projection`,
+and it contains Cells for cashflow projection.
 
-.. rubric:: Inheritance Structure
+Cells in this Space follow these naming conventions:
 
-.. figure:: /images/projects/simplelife/model/BaseProj/diagram1.png
-
-
-``Pols``:
-    Cells whose names start with ``Pols`` deal with number of policies.
+``pols_``:
+    Cells whose names start with ``pols_`` deal with number of policies.
     For example, ``pols_death(t)`` represents number of deaths between
     time ``t`` and ``t+1``.
 
 ``_pp``:
     Cells whose names end with ``_pp`` represent an amount per policy.
-    For example, ``claims_death_pp`` represents the death benefit per policy.
+    For example, ``claims_death_pp`` represents the death benefit per
+    policy.
 
-``Exps``:
-    Cells whose names start with ``Exps`` represents expense cashflows.
+``exps_``:
+    Cells whose names start with ``exps_`` represent expense cashflows.
     For example, ``exps_maint`` means the maintenance expense cashflow.
 
-``Claims``:
-    Cells whose names start with ``Claims`` represent benefit cashflows.
-    For example, ``claims_death(t)`` is the death benefit incurred
-    between ``t`` and ``t+1``.
+``claims_``:
+    Cells whose names start with ``claims_`` represent benefit
+    cashflows. For example, ``claims_death(t)`` is the death benefit
+    incurred between ``t`` and ``t+1``.
+
+The cells in this Space resolve their references through
+:mod:`~annuallife.TradLife_A.Projection`:
+
+* ``pol`` -> :mod:`~annuallife.TradLife_A.PolicyAttrs`
+* ``asmp`` -> :mod:`~annuallife.TradLife_A.Assumptions`
+* ``scen`` -> :mod:`~annuallife.TradLife_A.Economic`
+* ``comm_table`` -> :mod:`~annuallife.TradLife_A.CommTable`
+
+The integer ``idx`` from the enclosing
+:mod:`~annuallife.TradLife_A.Projection` ItemSpace is used to index into
+the per-policy NumPy arrays returned by ``pol`` and ``asmp``.
 
 """
 
@@ -87,7 +98,7 @@ def claims_living(t):
 
 
 def claims_mat(t):
-    """Matuirty benefits"""
+    """Maturity benefits"""
     return claims_mat_pp(t) * pols_maturity(t)
 
 
@@ -112,7 +123,7 @@ def claims_surr(t):
 
 
 def claims(t):
-    """Claims Total"""
+    """Total benefits"""
     return (claims_mat(t)
             + claims_death(t)
             + claims_acc_dth(t)
@@ -195,7 +206,7 @@ def insur_if_end(t):
 
 
 def int_accum_cf(t):
-    """Intrest on accumulated cashflows"""
+    """Interest on accumulated cashflows"""
     return (accum_cf(t)
             + premiums(t)
             - expenses(t)) * disc_rate_mth(t)
@@ -234,7 +245,7 @@ def pols_death(t):
 
 
 def pols_if_aft_mat(t):
-    """Number of policies: Maturity"""
+    """Number of policies: After maturity"""
     return pols_if(t) - pols_maturity(t)
 
 
@@ -474,12 +485,18 @@ def sum_assured(t):
 
 
 def proj_len():
+    """Projection length in years for the selected policy.
+
+    The projection ends at whichever comes first: the age at which
+    base mortality reaches 1 (returned by :func:`last_mort_age`),
+    or the end of the policy term.
+    """
     return min(last_mort_age() - pol.issue_age()[idx],
                pol.policy_term()[idx])
 
 
 def mort_rate(x):
-    """Bae mortality rate"""
+    """Base mortality rate at age ``x``"""
 
     return asmp.mortality_tables()[x, asmp.mort_array_index()[idx]]
 
@@ -581,12 +598,21 @@ def surr_charge(t):
 
 
 def last_mort_age():
-    """Age at which mortality becomes 1 for this policy"""
+    """Age at which the base mortality rate reaches 1 for this policy.
+
+    Refers to
+    :func:`~annuallife.TradLife_A.Assumptions.last_mort_age` for the
+    selected policy.
+    """
     return asmp.last_mort_age()[idx]
 
 
 def inflation_factor(t):
-    """Inflation factors to adjust expense cashflows"""
+    """Inflation factor at time ``t`` used to adjust expense cashflows.
+
+    Compounded from :func:`~annuallife.TradLife_A.Assumptions.inflation_rate`
+    starting from ``inflation_factor(0) = 1``.
+    """
     if t == 0:
         return 1
     else:
@@ -594,6 +620,11 @@ def inflation_factor(t):
 
 
 def disc_rate_mth(t):
+    """Discount rate at time ``t``.
+
+    Refers to
+    :func:`Economic[scen_id].disc_rate_mth<annuallife.TradLife_A.Economic.disc_rate_mth>`.
+    """
     return scen.disc_rate_mth(t)
 
 

--- a/lifelib/libraries/annuallife/TradLife_A/CommTable/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/CommTable/__init__.py
@@ -3,61 +3,54 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
-"""Commutation functions and actuarial notations
+"""Commutation functions and actuarial notations.
 
-The ``LifeTable`` Space provides
-commutation functions and actuarial notations, such as
-:math:`D_{x}` and :math:`\\require{enclose}{}_{f|}\\overline{A}_{x}`.
-Mortality tables are read from *input.xlsx* into an `ExcelRange`_ object.
-The `ExcelRange`_ object is bound to a Reference, :attr:`MortalityTable`.
-
-This Space is included in:
-
-* :mod:`simplelife`
-* :mod:`nestedlife`
-* :mod:`ifrs17sim`
-* :mod:`solvency2`
-
-.. _ExcelRange:
-   https://docs.modelx.io/en/latest/reference/dataclient.html#excelrange
+The :mod:`~annuallife.TradLife_A.CommTable` Space provides commutation
+functions and actuarial notations, such as :math:`D_{x}` and
+:math:`\\require{enclose}{}_{f|}\\overline{A}_{x}`.
+Mortality tables are read from the ``MortalityTables`` range in
+*input.xlsx* through
+:func:`~annuallife.TradLife_A.InputData.mortality_tables` and indexed
+through :func:`mortality_rates`.
 
 .. rubric:: Parameters
 
-``LifeTable`` Space is parameterized with :attr:`Sex`,
-:attr:`IntRate` and :attr:`TableID`::
+This Space is parameterized with :attr:`Sex`, :attr:`IntRate` and
+:attr:`TableID`::
 
-        >>> simplelife.LifeTable.parameters
-        ('Sex', 'IntRate', 'TableID')
+        >>> m.CommTable.parameters
+        ('Sex', 'IntRate', 'Table')
 
-Each ItemSpace represents commutations functions actuarial notations
+Each ItemSpace represents commutation functions and actuarial notations
 for a combination of :attr:`Sex`, :attr:`IntRate` and :attr:`TableID`.
-For example, ``LifeTable['M', 0.03, 1]`` contains commutation functions
-and actuarial notations for Male, the interest rate of 3%, mortality table 1.
-
+For example, ``CommTable[SexID.M, 0.03, 1]`` contains commutation
+functions and actuarial notations for Male, an interest rate of 3% and
+mortality table 1.
 
 Attributes:
-    Sex(:obj:`str`): 'M' or 'F' to indicate male or female column in the mortality table.
+    Sex: A :mod:`~annuallife.TradLife_A.Enums.SexID` code identifying
+        the column in the mortality table.
     IntRate(:obj:`float`): The constant interest rate for discounting.
-    TableID(:obj:`int`): The identifier of the mortality table
-
+    Table: Identifier of the mortality table within
+        :func:`~annuallife.TradLife_A.InputData.mortality_tables`.
 
 .. rubric:: References
 
 Attributes:
-    MortalityTable: `ExcelRange`_ object holding mortality tables.
-        The data is read from *MortalityTables* range in *input.xlsx*.
+    mortality_tables: Alias for
+        :func:`~annuallife.TradLife_A.InputData.mortality_tables`.
+    pol: Alias for :mod:`~annuallife.TradLife_A.PolicyAttrs`.
 
 Example:
 
-    An example of ``LifeTable`` in the :mod:`simplelife` model::
+    An example of :mod:`~annuallife.TradLife_A.CommTable`::
 
-        >>> simplelife.LifeTable['M', 0.03, 1].AnnDuenx(40, 10)
+        >>> m.CommTable[SexID.M, 0.03, 1].AnnDuenx(40, 10)
         8.725179890621531
 
 External Links:
     * `International actuarial notation by F.S.Perryman <https://www.casact.org/pubs/proceed/proceed49/49123.pdf>`_
     * `Actuarial notations on Wikipedia <https://en.wikipedia.org/wiki/Actuarial_notation>`_
-
 
 """
 
@@ -217,8 +210,12 @@ def qx(x):
 
 
 def mortality_rates():
+    """Mortality rates for the selected ``Sex`` and ``Table``.
 
-
+    Selects the column of :func:`~annuallife.TradLife_A.InputData.mortality_tables`
+    matching this Space's :attr:`Table` and :attr:`Sex` parameters and
+    returns the resulting per-age mortality rate Series.
+    """
     pos = list((t, getattr(SexID, s)) for t, s in mortality_tables().columns).index((Table, Sex))
 
     return mortality_tables().iloc[:, pos]

--- a/lifelib/libraries/annuallife/TradLife_A/Economic/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Economic/__init__.py
@@ -3,46 +3,38 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
-"""Economic scenarios
+"""Economic scenarios.
 
-The ``Economic`` spaces provides economic assumptions such as
-interest rate scenarios.
-
-This Space is included in:
-
-* :mod:`simplelife`
-* :mod:`nestedlife`
-* :mod:`ifrs17sim`
-* :mod:`solvency2`
-
-
-.. _ExcelRange:
-   https://docs.modelx.io/en/latest/reference/dataclient.html#excelrange
+The ``Economic`` Space provides economic assumptions, such as
+scenario interest rates used to discount cashflows.
 
 .. rubric:: Parameters
 
-``Economic`` Space is parameterized with :attr:`scen_id`::
+``Economic`` is parameterized with :attr:`scen_id`::
 
-        >>> simplelife.Economic.parameters
-        ('ScenID',)
+        >>> m.Economic.parameters
+        ('scen_id',)
 
-Each ItemSpace represents economic scenarios for a specific :attr:`scen_id`.
-For example, ``Economic[1]`` contains economic scenarios for scen_id 1.
+Each ItemSpace represents economic scenarios for a specific
+:attr:`scen_id`. For example, ``Economic[1]`` contains economic
+scenarios for ``scen_id`` 1.
 
 Attributes:
-    scen_id(:obj:`int`): Scenario ID
+    scen_id(:obj:`int`): Scenario ID.
 
 .. rubric:: References
 
 Attributes:
-    Scenario: `ExcelRange`_ object holding the data of interest rate
-        assumptions. The data is read from *Scenarios* range in *input.xlsx*.
+    input_data: Alias for :mod:`~annuallife.TradLife_A.InputData`.
+        Scenario interest rates are read from the ``Scenarios`` range
+        in *input.xlsx* through
+        :func:`~annuallife.TradLife_A.InputData.scenarios`.
 
 Example:
 
-    An example of ``Economic`` in the :mod:`simplelife` model::
+    An example of ``Economic`` in :mod:`~annuallife.TradLife_A`::
 
-        >>> simplelife.Economic[1].disc_rate_mth(0)
+        >>> m.Economic[1].disc_rate_mth(0)
         0.015
 
 """
@@ -61,14 +53,20 @@ _spaces = []
 # Cells
 
 def disc_rate_mth(t):
-    """Rates for discount cashflows"""
+    """Discount rate at time ``t``.
+
+    Read from the ``Scenarios`` range in *input.xlsx* (column
+    ``IntRate``) through
+    :func:`~annuallife.TradLife_A.InputData.scenarios`,
+    keyed by the current :attr:`scen_id` and ``t``.
+    """
     return input_data.scenarios()['IntRate'].at[(scen_id, t)]
 
 
 def invst_ret_rate(t):
-    """Rate of investment return
+    """Rate of investment return at time ``t``.
 
-    Set equal to the :func:`disc_rate_mth`
+    Set equal to :func:`disc_rate_mth`.
     """
     return disc_rate_mth(t)
 

--- a/lifelib/libraries/annuallife/TradLife_A/Enums/ProductID/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Enums/ProductID/__init__.py
@@ -3,6 +3,21 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
+"""Product type codes.
+
+Integer codes identifying the product of a policy. Used by
+:func:`~annuallife.TradLife_A.PolicyAttrs.product` and by the
+product-dependent branches in
+:func:`~annuallife.TradLife_A.BaseProj.gross_prem_rate` and
+:func:`~annuallife.TradLife_A.BaseProj.net_prem_rate`.
+
+Members:
+    TERM(:obj:`int`): Term insurance.
+    WL(:obj:`int`): Whole life insurance.
+    ENDW(:obj:`int`): Endowment insurance.
+
+"""
+
 from modelx.serialize.jsonvalues import *
 
 _formula = None

--- a/lifelib/libraries/annuallife/TradLife_A/Enums/RateBasisID/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Enums/RateBasisID/__init__.py
@@ -3,6 +3,23 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
+"""Rate basis codes.
+
+Integer codes used to select between the premium and valuation
+interest-rate / mortality-table bases. Consumed by
+:func:`~annuallife.TradLife_A.PolicyAttrs.int_rate` and
+:func:`~annuallife.TradLife_A.PolicyAttrs.table_id` and by the
+commutation-table lookups in
+:func:`~annuallife.TradLife_A.BaseProj.gross_prem_rate`,
+:func:`~annuallife.TradLife_A.BaseProj.net_prem_rate` and
+:func:`~annuallife.TradLife_A.BaseProj.reserve_nlp_rate`.
+
+Members:
+    PREM(:obj:`int`): Premium basis.
+    VAL(:obj:`int`): Valuation basis.
+
+"""
+
 from modelx.serialize.jsonvalues import *
 
 _formula = None

--- a/lifelib/libraries/annuallife/TradLife_A/Enums/SexID/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Enums/SexID/__init__.py
@@ -3,6 +3,20 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
+"""Sex codes.
+
+Integer codes used to identify the sex column of a mortality table.
+Returned per policy by :func:`~annuallife.TradLife_A.PolicyAttrs.sex`
+and consumed by the indexing logic in
+:func:`~annuallife.TradLife_A.Assumptions.mort_array_index` and
+:func:`~annuallife.TradLife_A.CommTable.mortality_rates`.
+
+Members:
+    M(:obj:`int`): Male.
+    F(:obj:`int`): Female.
+
+"""
+
 from modelx.serialize.jsonvalues import *
 
 _formula = None

--- a/lifelib/libraries/annuallife/TradLife_A/Enums/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Enums/__init__.py
@@ -3,6 +3,24 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
+"""Enum-style codes used across :mod:`~annuallife.TradLife_A`.
+
+This Space groups the small integer-coded enumerations referenced by
+the projection cells. Each enum is exposed as a child Space whose
+References hold the integer codes for its members:
+
+* :mod:`~annuallife.TradLife_A.Enums.ProductID` - product type codes
+  (``TERM``, ``WL``, ``ENDW``).
+* :mod:`~annuallife.TradLife_A.Enums.SexID` - sex codes used to index
+  mortality tables (``M``, ``F``).
+* :mod:`~annuallife.TradLife_A.Enums.RateBasisID` - rate-basis codes
+  used by the commutation lookup (``PREM``, ``VAL``).
+
+The three child spaces are also re-exported at the model level as
+``ProductID``, ``SexID`` and ``RateBasisID`` for convenience.
+
+"""
+
 from modelx.serialize.jsonvalues import *
 
 _formula = None

--- a/lifelib/libraries/annuallife/TradLife_A/InputData/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/InputData/__init__.py
@@ -68,7 +68,7 @@ def input_workbook():
 def policy_data():
     """Policy data table.
 
-    Returns the ``PolicyData`` named range as a `DataFrame`_, indexed by
+    Returns the ``PolicyData`` named range as a ``DataFrame``, indexed by
     the first column (the policy ID).
     """
     return get_named_range_as_df('PolicyData', index_len=1)
@@ -79,7 +79,7 @@ def mortality_tables():
 
     Reads the ``MortalityTables`` named range, which has a two-row
     header of ``(MortTable, Sex)`` and an age column, and returns a
-    `DataFrame`_ indexed by age with a ``MultiIndex`` over the columns.
+    ``DataFrame`` indexed by age with a ``MultiIndex`` over the columns.
     """
     wb = input_workbook()
 
@@ -129,14 +129,14 @@ def mort_table_last_ages():
 def assumption_tables():
     """Assumption tables by duration.
 
-    Returns the ``AsmpByDuration`` named range as a `DataFrame`_,
+    Returns the ``AsmpByDuration`` named range as a ``DataFrame``,
     indexed by the first column (typically duration).
     """
     return get_named_range_as_df('AsmpByDuration', index_len=1)
 
 
 def get_named_range_as_df(name, index_len=0):
-    """Read an Excel named range as a `DataFrame`_.
+    """Read an Excel named range as a ``DataFrame``.
 
     Args:
         name(:obj:`str`): The Excel defined-name to read.
@@ -166,7 +166,7 @@ _is_cached = False
 def scenarios():
     """Economic scenarios.
 
-    Returns the ``Scenarios`` named range as a `DataFrame`_, indexed by
+    Returns the ``Scenarios`` named range as a ``DataFrame``, indexed by
     the first two columns (scenario ID and time).
     """
     return get_named_range_as_df('Scenarios', index_len=2)
@@ -194,7 +194,7 @@ def discount_rate():
     """Per-policy premium discount based on sum-assured bands.
 
     Reads the ``LargePolDiscount`` named range, builds the breakpoints
-    of the sum-assured bands and returns a `Series`_ aligned with
+    of the sum-assured bands and returns a ``Series`` aligned with
     :func:`policy_data` giving the discount that applies to each policy.
     """
     table = get_named_range_as_dict('LargePolDiscount')
@@ -222,7 +222,7 @@ def prem_waiver_cost():
 def assumption(name):
     """Lookup column ``name`` of the ``AssumptionTable`` range.
 
-    Returns a `Series`_ keyed by the lookup levels (such as
+    Returns a ``Series`` keyed by the lookup levels (such as
     ``Product``, ``PolType``, ``Gen``) that are not entirely empty
     for column ``name``.
     """
@@ -232,7 +232,7 @@ def assumption(name):
 def product_spec(name):
     """Lookup column ``name`` of the ``ProductSpecTable`` range.
 
-    Returns a `Series`_ keyed by the lookup levels (such as
+    Returns a ``Series`` keyed by the lookup levels (such as
     ``Product``, ``PolType``, ``Gen``) that are not entirely empty
     for column ``name``.
     """
@@ -240,7 +240,7 @@ def product_spec(name):
 
 
 def get_param_series(range_name, col_name):
-    """Helper that reads column ``col_name`` from ``range_name`` as a `Series`_.
+    """Helper that reads column ``col_name`` from ``range_name`` as a ``Series``.
 
     The named range is loaded via :func:`get_named_range_as_df` with the
     first three columns used as a `MultiIndex`. Any index level that is

--- a/lifelib/libraries/annuallife/TradLife_A/InputData/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/InputData/__init__.py
@@ -3,61 +3,40 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
-"""input_data from files
+"""Input data loaded from *input.xlsx*.
 
-The ``input_data`` Space includes References that hold input values read from
-the Excel input file, *input.xlsx*.
-It also includes a few Cells to loock up values from the Referneces.
+The :mod:`~annuallife.TradLife_A.InputData` Space contains Cells that
+load values from named ranges in the Excel input file, *input.xlsx*,
+and helper Cells that turn those ranges into pandas objects ready for
+the rest of the model.
 
-The References in this Space refer to `ExcelRange`_ objects.
-The `ExcelRange` objects hold values read from ranges in the input
-Excel file, *input.xlsx*. `ExcelRange`_ objects are Python's mapping objects,
-so they support most methods that :obj:`dict` has, and can be
-converted to :obj:`dict`. The table below lists the References
-and their associated named ranges in *input.xlsx*.
+Per-policy attributes, assumption tables, scenarios, mortality tables
+and product specs are loaded on demand by the cells listed below. The
+workbook itself is opened lazily by :func:`input_workbook`.
 
-==================== ====================
- References            Named ranges
-==================== ====================
-PolicyData             PolicyData
-mortality_tables        mortality_tables
-AssumptionTables       AsmpByDuration
-Scenarios              Scenarios
-DiscountRate           LargePolDiscount
-==================== ====================
+The table below lists the cells and the Excel named ranges they read.
 
+============================== =====================  ==========================================
+ Cell                           Named range            Purpose
+============================== =====================  ==========================================
+:func:`policy_data`            ``PolicyData``         Per-policy attributes for model points.
+:func:`product_spec`           ``ProductSpecTable``   Per-product loading and rate tables.
+:func:`assumption`             ``AssumptionTable``    Lookup table of assumption keys.
+:func:`assumption_tables`      ``AsmpByDuration``     Duration-based mortality / lapse tables.
+:func:`mortality_tables`       ``MortalityTables``    Mortality tables keyed by Sex / Table.
+:func:`scenarios`              ``Scenarios``          Scenario interest-rate paths.
+:func:`discount_rate`          ``LargePolDiscount``   Premium discount by sum-assured band.
+:func:`prem_waiver_cost`       ``PremiumWaiverCost``  Premium-waiver cost lookup.
+:func:`const_params`           ``ConstParams``        Scalar parameters used across the model.
+============================== =====================  ==========================================
 
-.. rubric:: References in this Space
+.. rubric:: References
 
 Attributes:
-    PolicyData: `ExcelRange`_ object holding policy data. The data
-        is read from *PolicyData* range in *input.xlsx*.
-
-
-    ProductSpec: `ExcelRange`_ object holding the data of product specs.
-        The data is read from *ProductSpecTable* range in *input.xlsx*.
-
-    Assumption: `ExcelRange`_ object holding the data of the assumption table.
-        The data is read from *AssumptionTable* range in *input.xlsx*.
-
-    mortality_tables: `ExcelRange`_ object holding the data of mortality Tables.
-        The data is read from *mortality_tables* range in *input.xlsx*.
-
-    AssumptionTables: `ExcelRange`_ object holding the data of assumptions by duration.
-        The data is read from *AsmpByDuration* range in *input.xlsx*.
-
-    Scenarios: `ExcelRange`_ object holding the data of economic scenarios.
-        The data is read from *Scenarios* range in *input.xlsx*.
-
-    DiscountRate: `ExcelRange`_ object holding the data of premium discount.
-        The data is read from *LargePolDiscount* range in *input.xlsx*.
-
-
-.. _ExcelRange:
-   https://docs.modelx.io/en/latest/reference/dataclient.html#excelrange
-
-.. _mapping:
-   https://docs.python.org/3/glossary.html#term-mapping
+    input_file_name(:obj:`str`): Name of the Excel workbook to read.
+        Defaults to ``"input.xlsx"`` and is resolved relative to the
+        parent directory of the model.
+    openpyxl: The :mod:`openpyxl` module used to open the workbook.
 
 """
 
@@ -75,18 +54,33 @@ _spaces = []
 # Cells
 
 def input_workbook():
+    """Open and return the input Excel workbook.
+
+    Loads the workbook named :attr:`input_file_name` from the parent
+    directory of the model with ``data_only=True``, so that formula
+    cells return their last cached values.
+    """
     return openpyxl.load_workbook(
         _model.path.parent / input_file_name,
         data_only=True)
 
 
 def policy_data():
+    """Policy data table.
 
+    Returns the ``PolicyData`` named range as a `DataFrame`_, indexed by
+    the first column (the policy ID).
+    """
     return get_named_range_as_df('PolicyData', index_len=1)
 
 
 def mortality_tables():
+    """Mortality tables.
 
+    Reads the ``MortalityTables`` named range, which has a two-row
+    header of ``(MortTable, Sex)`` and an age column, and returns a
+    `DataFrame`_ indexed by age with a ``MultiIndex`` over the columns.
+    """
     wb = input_workbook()
 
     sheet_name, cell_range = next(wb.defined_names["MortalityTables"].destinations)
@@ -133,12 +127,22 @@ def mort_table_last_ages():
 
 
 def assumption_tables():
+    """Assumption tables by duration.
 
+    Returns the ``AsmpByDuration`` named range as a `DataFrame`_,
+    indexed by the first column (typically duration).
+    """
     return get_named_range_as_df('AsmpByDuration', index_len=1)
 
 
 def get_named_range_as_df(name, index_len=0):
+    """Read an Excel named range as a `DataFrame`_.
 
+    Args:
+        name(:obj:`str`): The Excel defined-name to read.
+        index_len(:obj:`int`, optional): Number of leading columns to
+            use as the DataFrame index. Defaults to 0 (no index column).
+    """
     wb = input_workbook()
 
     sheet_name, cell_range = next(wb.defined_names[name].destinations)
@@ -160,12 +164,20 @@ def get_named_range_as_df(name, index_len=0):
 _is_cached = False
 
 def scenarios():
+    """Economic scenarios.
 
+    Returns the ``Scenarios`` named range as a `DataFrame`_, indexed by
+    the first two columns (scenario ID and time).
+    """
     return get_named_range_as_df('Scenarios', index_len=2)
 
 
 def get_named_range_as_dict(name):
+    """Read a two-column Excel named range as a :obj:`dict`.
 
+    The first column of the range becomes the dict keys and the second
+    column becomes the values.
+    """
     wb = input_workbook()
 
     sheet_name, cell_range = next(wb.defined_names[name].destinations)
@@ -179,6 +191,12 @@ def get_named_range_as_dict(name):
 _is_cached = False
 
 def discount_rate():
+    """Per-policy premium discount based on sum-assured bands.
+
+    Reads the ``LargePolDiscount`` named range, builds the breakpoints
+    of the sum-assured bands and returns a `Series`_ aligned with
+    :func:`policy_data` giving the discount that applies to each policy.
+    """
     table = get_named_range_as_dict('LargePolDiscount')
 
     bins = [-np.inf] + list(table.keys())[:-1] + [np.inf]
@@ -193,21 +211,42 @@ def discount_rate():
 
 
 def prem_waiver_cost():
+    """Premium-waiver cost lookup as a :obj:`dict`.
 
+    Returns the ``PremiumWaiverCost`` named range, mapping the upper
+    bound of a policy-term band to its premium-waiver loading.
+    """
     return get_named_range_as_dict('PremiumWaiverCost')
 
 
 def assumption(name):
+    """Lookup column ``name`` of the ``AssumptionTable`` range.
 
+    Returns a `Series`_ keyed by the lookup levels (such as
+    ``Product``, ``PolType``, ``Gen``) that are not entirely empty
+    for column ``name``.
+    """
     return get_param_series('AssumptionTable', name)
 
 
 def product_spec(name):
+    """Lookup column ``name`` of the ``ProductSpecTable`` range.
+
+    Returns a `Series`_ keyed by the lookup levels (such as
+    ``Product``, ``PolType``, ``Gen``) that are not entirely empty
+    for column ``name``.
+    """
     return get_param_series('ProductSpecTable', name)
 
 
 def get_param_series(range_name, col_name):
+    """Helper that reads column ``col_name`` from ``range_name`` as a `Series`_.
 
+    The named range is loaded via :func:`get_named_range_as_df` with the
+    first three columns used as a `MultiIndex`. Any index level that is
+    entirely empty for ``col_name`` is dropped, and a partially empty
+    level raises :class:`ValueError`.
+    """
     df = get_named_range_as_df(range_name, index_len=3)[col_name].dropna()
 
     levels_to_drop = []
@@ -227,6 +266,7 @@ def get_param_series(range_name, col_name):
 _is_cached = False
 
 def const_params():
+    """Scalar parameters from the ``ConstParams`` named range as a :obj:`dict`."""
     return get_named_range_as_dict('ConstParams')
 
 

--- a/lifelib/libraries/annuallife/TradLife_A/PV/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/PV/__init__.py
@@ -5,10 +5,18 @@
 
 """Present Value mix-in Space
 
-This Space serves as a base Space for :mod:`~simplelife.model.Projection`
-Space, and it contains Cells to take the present value of projected cashflows.
+This Space serves as a base Space for
+:mod:`~annuallife.TradLife_A.Projection`,
+and it contains Cells that take the present value of projected
+cashflows produced by :mod:`~annuallife.TradLife_A.BaseProj`.
 
-.. figure:: /images/projects/simplelife/model/PV/diagram1.png
+Each present-value cell is defined recursively in ``t``: the recursion
+terminates at ``t > proj_len()`` by returning ``0``, where
+:func:`~annuallife.TradLife_A.BaseProj.proj_len` is the projection
+length for the selected policy. Discounting uses the
+:func:`~annuallife.TradLife_A.BaseProj.disc_rate_mth` cell that resolves
+to :func:`~annuallife.TradLife_A.Economic.disc_rate_mth` for the
+selected scenario.
 
 """
 
@@ -44,7 +52,7 @@ def pv_claims_death(t):
 
 
 def pv_claims_mat(t):
-    """Present value of matuirty benefits"""
+    """Present value of maturity benefits"""
     if t > proj_len():
         return 0
     else:
@@ -68,6 +76,11 @@ def pv_claims(t):
 
 
 def pv_check(t):
+    """Difference between :func:`pv_net_cf` and :func:`pv_net_cf_for_check`.
+
+    Used as a numerical sanity check; should be zero (within floating
+    point error) at every ``t``.
+    """
     return pv_net_cf(t) - pv_net_cf_for_check(t)
 
 
@@ -111,7 +124,12 @@ def pv_net_cf(t):
 
 
 def pv_net_cf_for_check(t):
-    """Present value of net cashflow"""
+    """Present value of net cashflow computed recursively for validation.
+
+    An alternative recursive definition of :func:`pv_net_cf` used by
+    :func:`pv_check` to verify that the closed-form sum and the
+    recursion agree.
+    """
     if t > proj_len():
         return 0
     else:

--- a/lifelib/libraries/annuallife/TradLife_A/PolicyAttrs/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/PolicyAttrs/__init__.py
@@ -3,48 +3,45 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
-"""Policy attributes and policy values
+"""Policy attributes and policy values.
 
-This Space is a child Space of :mod:`~simplelife.model.Projection`,
-and it holds policy attributes and policy values used
-by :mod:`~simplelife.model.Projection`
-and by :mod:`~simplelife.model.Projection.Assumptions`, another child Space
-of :mod:`~simplelife.model.Projection`.
+This Space holds policy attributes and policy-level values used by
+:mod:`~annuallife.TradLife_A.Projection` and its base spaces.
 
 Some Cells in this Space, such as :func:`product` and :func:`issue_age`,
-are for retrieving attributes for the selected policy from :attr:`PolicyData`.
-Some other Cells, such as :func:`GrossPremRate` are for
-calculating policy values for the policy from the attributes and
-product specs looked up through :attr:`SpecLookup`.
+retrieve attributes for the model points from
+:func:`~annuallife.TradLife_A.InputData.policy_data`. Other Cells,
+such as those used by
+:func:`~annuallife.TradLife_A.BaseProj.gross_prem_rate`, derive
+policy-level values from product specs looked up through
+:func:`~annuallife.TradLife_A.InputData.product_spec`.
 
-
-.. figure:: /images/projects/simplelife/model/Policy/diagram1.png
-
-
-.. rubric:: Parameters
-
-Since :mod:`~simplelife.model.Projection` is parameterized with
-:attr:`idx` and :attr:`scen_id`, this Space is also
-parameterized as a child space of :mod:`~simplelife.model.Projection`.
-For example, ``simplelife.Projection[1].Policy.GrossPremRate()``
-represents the gross premium rate for Policy 1.
-
-Attributes:
-    idx(:obj:`int`): Policy ID
-    scen_id(:obj:`int`, optional): Scenario ID, defaults to 1.
-
+Most cells return per-policy NumPy arrays whose layout matches the rows
+of :func:`~annuallife.TradLife_A.InputData.policy_data`, so callers
+index into them with the integer policy index ``idx``.
 
 .. rubric:: References
 
 Attributes:
-    life_table: :mod:`~simplelife.model.life_table` Space
-    PolicyData: `ExcelRange`_ object holding data read from the
-        Excel range *PolicyData* in *input.xlsx*.
-    SpecLookup: :func:`~simplelife.model.input_data.SpecLookup`
-    prem_term: Alias for :func:`policy_term`
+    input_data: Alias for :mod:`~annuallife.TradLife_A.InputData`.
+        Per-policy attributes are read from the ``PolicyData`` range
+        in *input.xlsx* via
+        :func:`~annuallife.TradLife_A.InputData.policy_data`,
+        and product specs from
+        :func:`~annuallife.TradLife_A.InputData.product_spec`.
+    life_table: Alias for :mod:`~annuallife.TradLife_A.CommTable`.
+    prem_term: Alias for :func:`policy_term`.
+    return_array(:obj:`bool`): When ``True`` (the default), helper
+        functions inherited from
+        :mod:`~annuallife.TradLife_A.Utilities` return NumPy arrays
+        instead of pandas objects.
 
-.. _ExcelRange:
-   https://docs.modelx.io/en/latest/reference/dataclient.html#excelrange
+.. rubric:: Inherited helpers
+
+Inherited from :mod:`~annuallife.TradLife_A.Utilities`:
+
+* :func:`~annuallife.TradLife_A.Utilities.pandas_to_array`
+* :func:`~annuallife.TradLife_A.Utilities.map_to_policies`
 
 """
 
@@ -157,10 +154,12 @@ def uern_prem_rate():
 
 
 def product():
+    """Per-policy product type as a :mod:`~annuallife.TradLife_A.Enums.ProductID` code."""
     return pandas_to_array(input_data.policy_data()['Product'].map(lambda s: getattr(ProductID, s)))
 
 
 def policy_type():
+    """Per-policy policy type from the ``PolType`` column of :func:`~annuallife.TradLife_A.InputData.policy_data`."""
     return pandas_to_array(input_data.policy_data()['PolType'])
 
 
@@ -169,60 +168,69 @@ gen = lambda: PolicyData[idx, 'Gen']
 channel = lambda: PolicyData[idx, 'Channel']
 
 def sex():
-
+    """Per-policy sex as a :mod:`~annuallife.TradLife_A.Enums.SexID` code."""
     return pandas_to_array(input_data.policy_data()['Sex'].map(lambda s: getattr(SexID, s)))
 
 
 duration = lambda: PolicyData[idx, 'Duration']
 
 def issue_age():
-
+    """Per-policy issue age in years."""
     return pandas_to_array(input_data.policy_data()['IssueAge'])
 
 
-def prem_freq(): 
+def prem_freq():
+   """Per-policy premium payment frequency (number of payments per year)."""
    return pandas_to_array(input_data.policy_data()['PremFreq'])
 
 
 def policy_term():
-
+    """Per-policy policy term in years."""
     return pandas_to_array(input_data.policy_data()['PolicyTerm'])
 
 
 def policy_count():
+    """Per-policy number of policies in the model point."""
     return pandas_to_array(input_data.policy_data()['PolicyCount'])
 
 
 def sum_assured():
+    """Per-policy sum assured."""
     return pandas_to_array(input_data.policy_data()['SumAssured'])
 
 
 def load_acq_sa_param1():
+    """Per-policy ``LoadAcqSAParam1`` parameter from ``ProductSpecTable``."""
     return pandas_to_array(
         map_to_policies(input_data.product_spec('LoadAcqSAParam1')))
 
 
 def load_acq_sa_param2():
+    """Per-policy ``LoadAcqSAParam2`` parameter from ``ProductSpecTable``."""
     return pandas_to_array(
         map_to_policies(input_data.product_spec('LoadAcqSAParam2')))
 
 
 def load_maint_prem_param1():
+    """Per-policy ``LoadMaintPremParam1`` parameter from ``ProductSpecTable``."""
     return pandas_to_array(
         map_to_policies(input_data.product_spec('LoadMaintPremParam1')))
 
 
 def load_maint_prem_param2():
+    """Per-policy ``LoadMaintPremParam2`` parameter from ``ProductSpecTable``."""
     return pandas_to_array(
         map_to_policies(input_data.product_spec('LoadMaintPremParam2')))
 
 
 def surr_charge_param1():
+    """Per-policy ``SurrChargeParam1`` parameter from ``ProductSpecTable``."""
     return pandas_to_array(
         map_to_policies(input_data.product_spec('SurrChargeParam1')))
 
 
 def surr_charge_param2():
+    """Per-policy ``SurrChargeParam2`` parameter from ``ProductSpecTable``."""
     return pandas_to_array(
         map_to_policies(input_data.product_spec('SurrChargeParam2')))
 

--- a/lifelib/libraries/annuallife/TradLife_A/Projection/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Projection/__init__.py
@@ -9,54 +9,39 @@ This Space is for projecting cashflows of individual model points.
 
 .. rubric:: Inheritance Structure
 
-The ``Projection`` Space inherits its contents from its
-base Spaces,
-:mod:`~simplelife.model.BaseProj` and :mod:`~simplelife.model.PV`.
-Projection items are inherited from :mod:`~simplelife.model.BaseProj`
-and the present values of the cashflow items are
-inherited from :mod:`~simplelife.model.BaseProj`.
-
-.. figure:: /images/projects/simplelife/model/Projection/diagram1.png
+The ``Projection`` Space inherits its contents from its base Spaces,
+:mod:`~annuallife.TradLife_A.BaseProj` and
+:mod:`~annuallife.TradLife_A.PV`.
+The projection cells are inherited from
+:mod:`~annuallife.TradLife_A.BaseProj`, and the present values of those
+cashflow items are inherited from :mod:`~annuallife.TradLife_A.PV`.
 
 .. rubric:: Parameters
 
-This Space is parametrized with ``idx`` and ``scen_id``::
+This Space is parameterized with ``idx`` and ``scen_id``::
 
-    >>> simplelife.Projection.parameters
-    ('PolicyID', 'ScenID')
+    >>> m.Projection.parameters
+    ('idx', 'scen_id')
 
-Calling this space with a pair of integers returns the ItemSpace
-for the policy ID and scenario ID. ``scen_id`` has a default value of 1,
-so for example ``Projection[1]`` represents the Projection Space for Policy 1.
+Calling this Space with a pair of integers returns the ItemSpace for
+the policy index and scenario ID. ``scen_id`` has a default value of 1,
+so for example ``Projection[0]`` represents the Projection Space for
+the first policy under scenario 1.
 
 Attributes:
-    idx(:obj:`int`): Policy ID
+    idx(:obj:`int`): 0-based policy index into the policy data array.
     scen_id(:obj:`int`, optional): Scenario ID, defaults to 1.
-
-.. rubric:: Composition Structure
-
-This Space has child Spaces,
-:mod:`~simplelife.model.Projection.Policy` and :mod:`~simplelife.model.Projection.Assumptions`.
-The :mod:`~simplelife.model.Projection.Policy` Space contains Cells representing policy attributes, such as
-product type, issue age, sum assured, etc.
-It also contains Cells for calculating policy values such as premium rates and
-cash surrender value rates.
-The :mod:`~simplelife.model.Projection.Assumptions` Space contains Cells to pick up assumption data for
-its model point.
-
-.. figure:: /images/projects/simplelife/model/Projection/diagram2.png
-
-
 
 .. rubric:: References
 
-The following attributes are referenced in this Space by its base Spaces.
+The following references are resolved in this Space and its base
+Spaces:
 
 Attributes:
-    pol: Alias for :mod:`~simplelife.model.Projection.Policy` child Space
-    asmp: Alias for :mod:`~simplelife.model.Projection.Assumptions` child Space
-    scen: Alias for :mod:`~simplelife.model.Economic` Space
-
+    pol: Alias for :mod:`~annuallife.TradLife_A.PolicyAttrs`.
+    asmp: Alias for :mod:`~annuallife.TradLife_A.Assumptions`.
+    scen: Alias for :mod:`~annuallife.TradLife_A.Economic`.
+    comm_table: Alias for :mod:`~annuallife.TradLife_A.CommTable`.
 
 """
 

--- a/lifelib/libraries/annuallife/TradLife_A/Utilities/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Utilities/__init__.py
@@ -3,6 +3,21 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
+"""Helper cells shared by :mod:`~annuallife.TradLife_A.Assumptions` and
+:mod:`~annuallife.TradLife_A.PolicyAttrs`.
+
+This Space is used as a base Space (``_bases``) for
+:mod:`~annuallife.TradLife_A.Assumptions` and
+:mod:`~annuallife.TradLife_A.PolicyAttrs`, which both derive their
+per-policy values by mapping pandas tables onto the rows of the policy
+data.
+
+The cells in this Space rely on a ``return_array`` reference, which is
+defined by the inheriting space (``True`` to convert results to NumPy
+arrays, ``False`` to keep them as pandas objects).
+
+"""
+
 from modelx.serialize.jsonvalues import *
 
 _formula = None
@@ -17,13 +32,29 @@ _spaces = []
 # Cells
 
 def pandas_to_array(df_or_series):
+    """Return ``df_or_series`` as a NumPy array or as is.
 
+    If the inheriting space sets ``return_array = True`` (the default
+    for :mod:`~annuallife.TradLife_A.Assumptions` and
+    :mod:`~annuallife.TradLife_A.PolicyAttrs`), the input is converted
+    via :meth:`~pandas.Series.to_numpy`. Otherwise the original pandas
+    object is returned unchanged.
+    """
     return df_or_series.to_numpy() if return_array else df_or_series
 
 
 _is_cached = False
 
 def map_to_policies(series):
+    """Reindex an assumption ``series`` to one entry per policy.
+
+    Looks up the values of ``series`` for each row of
+    :func:`~annuallife.TradLife_A.InputData.policy_data` using the
+    columns identified by ``series.index.names`` (e.g. ``Product``,
+    ``PolType``, ``Gen``), and returns a Series whose index matches
+    ``policy_data`` so it aligns with the per-policy NumPy arrays used
+    elsewhere in the model.
+    """
     index_names = series.index.names
     target = input_data.policy_data()[index_names]
 

--- a/lifelib/libraries/annuallife/TradLife_A/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/__init__.py
@@ -3,6 +3,64 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
+"""Annual projection model for traditional life insurance policies.
+
+:mod:`~annuallife.TradLife_A` is the modern successor of the
+:mod:`simplelife` model. It projects insurance cashflows and their
+present values for traditional life policies on an annual time step,
+re-expressed in snake-case naming and refactored for an array-based
+input.
+
+A projection is performed by selecting a model point through the integer
+parameter ``idx``, the 0-based index into the policy data array read
+from *input.xlsx*. For example, the present value of net cashflows for
+the first policy is obtained as::
+
+    >>> m.Projection[0].pv_net_cf(0)
+
+
+.. rubric:: Spaces
+
+The model is composed of the following spaces:
+
+* :mod:`~annuallife.TradLife_A.InputData`: References to Excel ranges
+  read from *input.xlsx* and helper cells for converting them to pandas
+  objects.
+* :mod:`~annuallife.TradLife_A.Economic`: Parametric space holding
+  scenario-dependent economic assumptions (parameter ``scen_id``).
+* :mod:`~annuallife.TradLife_A.BaseProj`: Base space of
+  :mod:`~annuallife.TradLife_A.Projection` containing per-period
+  cashflow projection cells.
+* :mod:`~annuallife.TradLife_A.PV`: Mix-in base space of
+  :mod:`~annuallife.TradLife_A.Projection` containing the present-value
+  cells.
+* :mod:`~annuallife.TradLife_A.Projection`: Parametric space whose
+  ItemSpaces carry out projections for each model point (parameters
+  ``idx`` and ``scen_id``).
+* :mod:`~annuallife.TradLife_A.Assumptions`: Assumption parameters and
+  rates used by :mod:`~annuallife.TradLife_A.Projection`.
+* :mod:`~annuallife.TradLife_A.PolicyAttrs`: Policy attributes and
+  policy-level values such as premium and surrender rates.
+* :mod:`~annuallife.TradLife_A.Utilities`: Base space of
+  :mod:`~annuallife.TradLife_A.Assumptions` and
+  :mod:`~annuallife.TradLife_A.PolicyAttrs` providing helper cells.
+* :mod:`~annuallife.TradLife_A.CommTable`: Parametric space providing
+  commutation functions and actuarial notations (parameters ``Sex``,
+  ``IntRate`` and ``Table``).
+* :mod:`~annuallife.TradLife_A.Enums`: Container for enum types
+  (``ProductID``, ``SexID``, ``RateBasisID``) used across the model.
+
+.. rubric:: References
+
+Attributes:
+    pd: The :mod:`pandas` module.
+    np: The :mod:`numpy` module.
+    ProductID: Alias for :mod:`~annuallife.TradLife_A.Enums.ProductID`.
+    SexID: Alias for :mod:`~annuallife.TradLife_A.Enums.SexID`.
+    RateBasisID: Alias for :mod:`~annuallife.TradLife_A.Enums.RateBasisID`.
+
+"""
+
 from modelx.serialize.jsonvalues import *
 
 _name = "TradLife_A"

--- a/makedocs/source/libraries/annuallife/Assumptions.rst
+++ b/makedocs/source/libraries/annuallife/Assumptions.rst
@@ -9,7 +9,6 @@ Formulas
 
 .. autosummary::
 
-   ~mort_rate
    ~cnsmp_tax
    ~comm_init_prem
    ~comm_ren_prem
@@ -33,8 +32,6 @@ Formulas
 
 Cells Descriptions
 ------------------
-
-.. autofunction:: mort_rate
 
 .. autofunction:: cnsmp_tax
 


### PR DESCRIPTION
## Summary

This PR significantly improves the documentation across the TradLife_A model by replacing outdated references to simplelife with accurate descriptions of the annual projection model, adding comprehensive docstrings to cells, and clarifying the model's architecture and data flow.

## Key Changes

- **InputData module**: Rewrote module docstring to explain the lazy-loading pattern and added a reference table mapping cells to Excel named ranges. Added docstrings to all public cells explaining their purpose and data sources.

- **Assumptions module**: Updated module docstring to describe the annual model's array-based approach, added docstrings to cells explaining mortality tables, assumption lookups, and index resolution logic.

- **PolicyAttrs module**: Clarified that cells return per-policy NumPy arrays indexed by policy index, added docstrings to all attribute accessor cells.

- **BaseProj module**: Updated module docstring with accurate naming conventions (snake_case), clarified cell naming patterns (pols_, _pp, exps_, claims_), and added docstrings explaining projection length calculation and discount rate resolution.

- **CommTable module**: Rewrote module docstring to reference the correct input data sources, updated parameter descriptions to use actual parameter names (Sex, IntRate, Table), and added docstring to mortality_rates() cell.

- **Economic module**: Simplified module docstring, updated parameter documentation, and added docstring to disc_rate_mth() explaining the data source.

- **Projection module**: Updated module docstring to remove outdated inheritance diagrams and clarify the parameterization with idx and scen_id.

- **PV module**: Clarified that present-value cells use recursive definitions with termination at proj_len(), and added docstrings to validation cells.

- **Utilities module**: Added module docstring explaining the helper cells and their role in mapping pandas tables to per-policy arrays.

- **Enum modules** (Enums, ProductID, SexID, RateBasisID, AsmpID): Added comprehensive docstrings explaining the purpose of each enum and how they're used throughout the model.

- **TradLife_A root module**: Added comprehensive module docstring describing the model's purpose, spaces, and key references.

- **Minor fixes**: Corrected typos ("Matuirty" → "Maturity", "Intrest" → "Interest", "Bae" → "Base").

## Implementation Details

- All docstrings follow NumPy/Google style with proper cross-references to related cells and modules using Sphinx roles.
- Removed outdated references to simplelife, nestedlife, ifrs17sim, and solvency2 models.
- Replaced generic ExcelRange documentation with specific references to actual Excel named ranges and input data cells.
- Clarified the array-based input model where per-policy values are indexed by integer policy index rather than policy ID.

https://claude.ai/code/session_012v7FkwD5Cn6Z2E9QrGgpcq