### PR TITLE
Add deprecation warnings to obsolete project documentation

### DIFF
--- a/makedocs/source/projects/fastlife.rst
+++ b/makedocs/source/projects/fastlife.rst
@@ -8,6 +8,12 @@ Project **fastlife**
 
 |modelx badge|
 
+.. warning::
+
+   :mod:`fastlife` is obsolete and will be replaced in a future release,
+   because the model is based on :mod:`simplelife`,
+   which has been superseded by :mod:`annuallife`.
+
 This project includes the **fastlife** model. The firstlife model
 calculates the present values of the net insurance cashflows.
 The calculation results are the same as the model in :doc:`simplelife`.

--- a/makedocs/source/projects/ifrs17sim.rst
+++ b/makedocs/source/projects/ifrs17sim.rst
@@ -8,6 +8,12 @@ Project **ifrs17sim**
 
 |modelx badge|
 
+.. warning::
+
+   :mod:`ifrs17sim` is obsolete and will be replaced in a future release,
+   because the model is based on :mod:`simplelife`,
+   which has been superseded by :mod:`annuallife`.
+
 **ifrs17sim** is a project for simulating IFRS17
 financial statements on sample insurance contracts.
 

--- a/makedocs/source/projects/nestedlife.rst
+++ b/makedocs/source/projects/nestedlife.rst
@@ -11,6 +11,12 @@ Project **nestedlife**
 
 |modelx badge|
 
+.. warning::
+
+   :mod:`nestedlife` is obsolete and will be replaced in a future release,
+   because the model is based on :mod:`simplelife`,
+   which has been superseded by :mod:`annuallife`.
+
 The **nestedlife** project has the same annual projection
 model of basic traditional life policies
 as :mod:`simplelife`, but at each projection step,

--- a/makedocs/source/projects/simplelife.rst
+++ b/makedocs/source/projects/simplelife.rst
@@ -8,6 +8,11 @@ Project **simplelife**
 
 |modelx badge|
 
+.. warning::
+
+   :mod:`simplelife` has been superseded by :mod:`annuallife`,
+   and will be removed in a future release.
+
 This project includes the **simplelife** model,
 which is an annual projection model of basic traditional life policies.
 The simplelife model is designed in such a way that allows you to


### PR DESCRIPTION
## Summary
Added deprecation warnings to the documentation of four projects that are based on or are the `simplelife` model, which has been superseded by `annuallife`.

## Key Changes
- **simplelife.rst**: Added warning that `simplelife` has been superseded by `annuallife` and will be removed in a future release
- **fastlife.rst**: Added warning that `fastlife` is obsolete and will be replaced, as it's based on the superseded `simplelife`
- **ifrs17sim.rst**: Added warning that `ifrs17sim` is obsolete and will be replaced, as it's based on the superseded `simplelife`
- **nestedlife.rst**: Added warning that `nestedlife` is obsolete and will be replaced, as it's based on the superseded `simplelife`

## Implementation Details
Each warning uses reStructuredText `.. warning::` directive to clearly communicate to users that these projects are deprecated. The warnings explain the deprecation reason (being based on `simplelife` which has been superseded by `annuallife`) and indicate that replacements will be available in future releases.

https://claude.ai/code/session_01DzrKCXFHvVhxFHKEnSgKhw