### PR TITLE
DOC: Improve the annuallife Overview page (#116)

### DIFF
--- a/doc/source/libraries/annuallife/index.rst
+++ b/doc/source/libraries/annuallife/index.rst
@@ -6,32 +6,33 @@ The **annuallife** Library
 
 |modelx badge|
 
-.. warning::
-
-   :mod:`annuallife` is in its active development phase, and its contents are
-   subject to change.
-
 Overview
 -----------
 
-The **annuallife** library is the updated successor of the legacy
-:ref:`project_simplelife` project. It packages
-:mod:`~annuallife.TradLife_A`, an annual projection model of basic
-traditional life policies.
+The **annuallife** library packages :mod:`~annuallife.TradLife_A`, an
+annual new business projection model of basic traditional life policies,
+covering term, whole life and endowment products, built with modelx.
 
-:mod:`~annuallife.TradLife_A` projects life insurance cashflows and their
+:mod:`~annuallife.TradLife_A` projects liability cashflows and their
 present values for policies represented by model points. Projected items
 include:
 
-* Premium income,
+* Premiums,
 * Commissions and expenses,
-* Benefit outgo.
+* Claims.
 
-Cells for investment income, change in reserve and profits are included
-but not tested.
+Premiums are calculated using commutation functions.
 
-Compared with the original *simplelife* model, :mod:`~annuallife.TradLife_A`
-introduces:
+Cells for investment income reserves are defined but not implemented.
+
+See :mod:`~annuallife.TradLife_A` for more details.
+
+Successor of simplelife
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The **annuallife** library is the updated successor of the legacy
+:ref:`project_simplelife` project. Compared with the original
+*simplelife* model, :mod:`~annuallife.TradLife_A` introduces:
 
 * **Snake-case cell and reference names** following the
   :mod:`basiclife.BasicTerm_SC` naming convention
@@ -45,8 +46,6 @@ introduces:
 * **A renamed input space.** The space holding *input.xlsx*-backed
   References is now ``InputData`` and is referenced as ``input_data``
   by the rest of the model.
-
-See :mod:`~annuallife.TradLife_A` for more details.
 
 How to Use the Library
 ------------------------------


### PR DESCRIPTION
Closes #116.

## Summary

Reworks the Overview section of `doc/source/libraries/annuallife/index.rst` so the page leads with what matters to library users and demotes the simplelife-lineage detail.

## What changed

- Removed the active-development-phase warning.
- Rewrote the opening sentence: `annuallife` packages `TradLife_A`, an annual **new business** projection model of basic traditional life policies, covering **term, whole life and endowment** products, built with modelx. The "successor of simplelife" framing was removed from the first sentence.
- Terminology: "life insurance cashflows" -> "liability cashflows"; cashflow list is now Premiums / Commissions and expenses / Claims.
- Added "Premiums are calculated using commutation functions."
- Replaced "Cells for investment income, change in reserve and profits are included but not tested." with "Cells for investment income reserves are defined but not implemented."
- Moved the simplelife-lineage content (and the `simplelife` comparison list) into a new "Successor of simplelife" subsection placed after the main description.
- "See TradLife_A for more details." now closes the main description, before the subsection.

## Reviewer notes

- Documentation-only change; a single `.rst` file is touched.
- Product types were sourced from `TradLife_A/Enums/ProductID` (TERM, WL, ENDW).

🤖 Generated with [Claude Code](https://claude.com/claude-code)