### PR TITLE
DOC: Improve the TradLife_A model docstring (#118)

### DIFF
--- a/lifelib/libraries/annuallife/TradLife_A/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/__init__.py
@@ -3,59 +3,130 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
-"""Annual projection model for traditional life insurance policies.
+"""Annual new business projection model of basic traditional life policies.
 
 Overview
 --------
 
-:mod:`~annuallife.TradLife_A` is an annual projection model for basic
-traditional life policies. It is the modern successor of the
-:ref:`project_simplelife` model and shares the same calculation logic,
-re-expressed in snake-case naming and refactored for an array-based
-input.
+:mod:`~annuallife.TradLife_A` is an annual new business projection model
+of basic traditional life policies, covering term, whole life and
+endowment products, built with
+`modelx <https://modelx.io/>`__.
 
-A projection is performed by selecting a model point through the integer
-parameter ``idx``, which is the 0-based index into the policy data array
-read from *input.xlsx*. For example, the present value of net cashflows
-for the first policy is obtained as::
+It projects liability cashflows and their present values for policies
+represented by model points. Projected items include:
+
+* Premiums,
+* Commissions and expenses,
+* Claims.
+
+Premiums are calculated using commutation functions. Cells for investment
+income reserves are defined but not implemented.
+
+Computation flow
+^^^^^^^^^^^^^^^^
+
+Model point data, product specifications, assumptions and economic
+scenarios are all held in an external Excel workbook, *input.xlsx*.
+
+The spaces are wired together as shown below, and the computation
+proceeds as follows.
+
+.. mermaid::
+
+    graph LR
+        Projection --> Economic
+        Projection --> Assumptions
+        Projection --> PolicyAttrs
+        Projection --> CommTable
+        Economic --> InputData
+        Assumptions --> InputData
+        PolicyAttrs --> InputData
+        CommTable --> InputData
+
+* The data is read into the model from the input file in
+  :mod:`~annuallife.TradLife_A.InputData`, and held there as
+  :mod:`pandas` DataFrames and dicts.
+* :mod:`~annuallife.TradLife_A.InputData` is referenced by
+  :mod:`~annuallife.TradLife_A.PolicyAttrs` and
+  :mod:`~annuallife.TradLife_A.Assumptions`, where policy attributes and
+  assumptions are mapped to model points.
+* :mod:`~annuallife.TradLife_A.InputData` is also referenced by
+  :mod:`~annuallife.TradLife_A.Economic`, where discount rates are
+  calculated.
+* :mod:`~annuallife.TradLife_A.CommTable` calculates commutation
+  functions, and defines actuarial notations. They are used by
+  :mod:`~annuallife.TradLife_A.Projection` to calculate the premium rate
+  for each model point. Mortality rates are provided through
+  :mod:`~annuallife.TradLife_A.InputData`.
+  :mod:`~annuallife.TradLife_A.CommTable` takes three parameters,
+  ``Sex``, ``IntRate`` and ``Table`` (sex, interest rate and mortality
+  table id).
+* :mod:`~annuallife.TradLife_A.Projection` carries out the projection by
+  model point. It takes two parameters: ``idx`` (mandatory) to identify
+  a model point, and ``scen_id`` (optional) to select the economic
+  scenario, defaulting to 1. Policy attributes and assumptions are
+  received from cells in
+  :mod:`~annuallife.TradLife_A.PolicyAttrs` and
+  :mod:`~annuallife.TradLife_A.Assumptions`, which return their values by
+  model point in 1-D :mod:`numpy` arrays, so the ``idx`` parameter
+  indicates the array index, starting from 0.
+* The projection logic is not defined directly in
+  :mod:`~annuallife.TradLife_A.Projection`. Instead, the space inherits
+  all of its logic from two base spaces,
+  :mod:`~annuallife.TradLife_A.BaseProj` and
+  :mod:`~annuallife.TradLife_A.PV`.
+
+For example, the present value of net cashflows for the first model
+point is obtained as::
 
     >>> m.Projection[0].pv_net_cf(0)
-
-For the same model, ``m.Projection[idx].pv_net_cf(0)`` matches the legacy
-``simplelife.Projection[idx + 1].PV_NetCashflow(0)``.
 
 Model Structure
 ---------------
 
 In :mod:`~annuallife.TradLife_A`, the following spaces are defined.
 
-* :mod:`~annuallife.TradLife_A.InputData`: Holds References to the
-  Excel ranges read from *input.xlsx* and helper cells for converting
-  them to pandas objects.
-* :mod:`~annuallife.TradLife_A.Economic`: Parametric space holding
-  scenario-dependent economic assumptions; parameter ``scen_id``.
-* :mod:`~annuallife.TradLife_A.BaseProj`: Base space of
-  :mod:`~annuallife.TradLife_A.Projection` containing the cells that
-  produce the per-period cashflow projections.
-* :mod:`~annuallife.TradLife_A.PV`: Mixin base space of
-  :mod:`~annuallife.TradLife_A.Projection` containing the cells that
-  compute the present values of those cashflows.
-* :mod:`~annuallife.TradLife_A.Projection`: Parametric space whose
-  dynamic ItemSpaces carry out projections for each model point;
-  parameters ``idx`` and ``scen_id``.
-* :mod:`~annuallife.TradLife_A.Assumptions`: Holds assumption parameters
-  and rates used by :mod:`~annuallife.TradLife_A.Projection`.
-* :mod:`~annuallife.TradLife_A.PolicyAttrs`: Holds policy attributes and
-  policy-level values such as premium and surrender rates used by
-  :mod:`~annuallife.TradLife_A.Projection`.
-* :mod:`~annuallife.TradLife_A.Utilities`: Base space of
-  :mod:`~annuallife.TradLife_A.Assumptions` and
-  :mod:`~annuallife.TradLife_A.PolicyAttrs` providing helper cells.
-* :mod:`~annuallife.TradLife_A.CommTable`: Parametric space providing
-  commutation functions and actuarial notations; parameters ``Sex``,
-  ``IntRate`` and ``Table``.
-* :mod:`~annuallife.TradLife_A.Enums`: Container for enum types
-  (``ProductID``, ``SexID``, ``RateBasisID``) used across the model.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Space
+     - Description
+   * - :mod:`~annuallife.TradLife_A.InputData`
+     - Reads *input.xlsx* and holds its named ranges as :mod:`pandas`
+       DataFrames and dicts.
+   * - :mod:`~annuallife.TradLife_A.Economic`
+     - Parametric space holding scenario-dependent economic assumptions;
+       parameter ``scen_id``.
+   * - :mod:`~annuallife.TradLife_A.BaseProj`
+     - Base space of :mod:`~annuallife.TradLife_A.Projection` containing
+       the cells that produce the per-period cashflow projections.
+   * - :mod:`~annuallife.TradLife_A.PV`
+     - Base space of :mod:`~annuallife.TradLife_A.Projection` containing
+       the cells that compute the present values of those cashflows.
+   * - :mod:`~annuallife.TradLife_A.Projection`
+     - Parametric space whose dynamic ItemSpaces carry out projections
+       for each model point; parameters ``idx`` and ``scen_id``.
+   * - :mod:`~annuallife.TradLife_A.Assumptions`
+     - Holds assumption parameters and rates used by
+       :mod:`~annuallife.TradLife_A.Projection`.
+   * - :mod:`~annuallife.TradLife_A.PolicyAttrs`
+     - Holds policy attributes and policy-level values such as premium
+       and surrender rates used by
+       :mod:`~annuallife.TradLife_A.Projection`.
+   * - :mod:`~annuallife.TradLife_A.Utilities`
+     - Base space of :mod:`~annuallife.TradLife_A.Assumptions` and
+       :mod:`~annuallife.TradLife_A.PolicyAttrs` providing helper cells.
+   * - :mod:`~annuallife.TradLife_A.CommTable`
+     - Parametric space providing commutation functions and actuarial
+       notations; parameters ``Sex``, ``IntRate`` and ``Table``.
+   * - :mod:`~annuallife.TradLife_A.Enums`
+     - Container for the enum types used across the model.
+
+:mod:`~annuallife.TradLife_A.Enums` contains the enum types as child
+spaces, and :mod:`~annuallife.TradLife_A.Assumptions` contains an
+``AsmpID`` child space.
 
 Inheritance
 ^^^^^^^^^^^
@@ -64,10 +135,23 @@ Inheritance
 :mod:`~annuallife.TradLife_A.BaseProj` and
 :mod:`~annuallife.TradLife_A.PV`, so projection cells and their
 present-value counterparts share the same parameter scope.
+
+.. mermaid::
+
+    graph BT
+        BaseProj --> Projection
+        PV --> Projection
+
 :mod:`~annuallife.TradLife_A.Assumptions` and
 :mod:`~annuallife.TradLife_A.PolicyAttrs` inherit from
 :mod:`~annuallife.TradLife_A.Utilities`, which contributes the
 ``pandas_to_array`` and ``map_to_policies`` helpers.
+
+.. mermaid::
+
+    graph BT
+        Utilities --> Assumptions
+        Utilities --> PolicyAttrs
 
 Cross-space references
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -75,15 +159,30 @@ Cross-space references
 The cells in :mod:`~annuallife.TradLife_A.Projection` and its base
 spaces resolve a number of References to other spaces:
 
-* ``pol`` -> :mod:`~annuallife.TradLife_A.PolicyAttrs`
-* ``asmp`` -> :mod:`~annuallife.TradLife_A.Assumptions`
 * ``scen`` -> :mod:`~annuallife.TradLife_A.Economic`
+* ``asmp`` -> :mod:`~annuallife.TradLife_A.Assumptions`
+* ``pol`` -> :mod:`~annuallife.TradLife_A.PolicyAttrs`
 * ``comm_table`` -> :mod:`~annuallife.TradLife_A.CommTable`
 
-In :mod:`~annuallife.TradLife_A.Assumptions` and
-:mod:`~annuallife.TradLife_A.PolicyAttrs`, the data space is referenced
-as ``input_data`` (renamed from the legacy ``Input``) and points at
-:mod:`~annuallife.TradLife_A.InputData`.
+:mod:`~annuallife.TradLife_A.Economic`,
+:mod:`~annuallife.TradLife_A.Assumptions` and
+:mod:`~annuallife.TradLife_A.PolicyAttrs` each reference the
+:mod:`~annuallife.TradLife_A.InputData` space as ``input_data``, while
+:mod:`~annuallife.TradLife_A.CommTable` references the
+:func:`~annuallife.TradLife_A.InputData.mortality_tables` cells defined
+in :mod:`~annuallife.TradLife_A.InputData` as ``mortality_tables``.
+
+.. mermaid::
+
+    graph LR
+        Projection -- scen --> Economic
+        Projection -- asmp --> Assumptions
+        Projection -- pol --> PolicyAttrs
+        Projection -- comm_table --> CommTable
+        Economic -- input_data --> InputData
+        Assumptions -- input_data --> InputData
+        PolicyAttrs -- input_data --> InputData
+        CommTable -- mortality_tables --> InputData
 
 Input File
 ----------
@@ -96,22 +195,40 @@ folder. The default file name is set by the
 The workbook defines the following named ranges, picked up through cells
 in :mod:`~annuallife.TradLife_A.InputData`:
 
-.. table::
-   :widths: 30 30 40
+.. list-table::
+   :header-rows: 1
+   :widths: 25 40 35
 
-   ============================================================== ====================== =========================================
-   Cell                                                           Excel named range      Purpose
-   ============================================================== ====================== =========================================
-   :func:`~annuallife.TradLife_A.InputData.policy_data`            ``PolicyData``         Per-policy attributes for model points
-   :func:`~annuallife.TradLife_A.InputData.product_spec`           ``ProductSpecTable``   Per-product loading and rate tables
-   :func:`~annuallife.TradLife_A.InputData.assumption`             ``AssumptionTable``    Lookup table of assumption keys
-   :func:`~annuallife.TradLife_A.InputData.assumption_tables`      ``AsmpByDuration``     Duration-based mortality / lapse tables
-   :func:`~annuallife.TradLife_A.InputData.mortality_tables`       ``MortalityTables``    Mortality tables keyed by Sex / Table
-   :func:`~annuallife.TradLife_A.InputData.scenarios`              ``Scenarios``          Scenario interest-rate paths
-   :func:`~annuallife.TradLife_A.InputData.discount_rate`          ``LargePolDiscount``   Premium discount by sum-assured band
-   :func:`~annuallife.TradLife_A.InputData.prem_waiver_cost`       ``PremiumWaiverCost``  Premium-waiver cost lookup
-   :func:`~annuallife.TradLife_A.InputData.const_params`           ``ConstParams``        Scalar parameters used across the model
-   ============================================================== ====================== =========================================
+   * - External named range
+     - Cells
+     - Purpose
+   * - ``PolicyData``
+     - :func:`~annuallife.TradLife_A.InputData.policy_data`
+     - Per-policy attributes for model points
+   * - ``ProductSpecTable``
+     - :func:`~annuallife.TradLife_A.InputData.product_spec`
+     - Per-product loading and rate tables
+   * - ``AssumptionTable``
+     - :func:`~annuallife.TradLife_A.InputData.assumption`
+     - Lookup table of assumption keys
+   * - ``AsmpByDuration``
+     - :func:`~annuallife.TradLife_A.InputData.assumption_tables`
+     - Duration-based mortality / lapse tables
+   * - ``MortalityTables``
+     - :func:`~annuallife.TradLife_A.InputData.mortality_tables`
+     - Mortality tables keyed by Sex / Table
+   * - ``Scenarios``
+     - :func:`~annuallife.TradLife_A.InputData.scenarios`
+     - Scenario interest-rate paths
+   * - ``LargePolDiscount``
+     - :func:`~annuallife.TradLife_A.InputData.discount_rate`
+     - Premium discount by sum-assured band
+   * - ``PremiumWaiverCost``
+     - :func:`~annuallife.TradLife_A.InputData.prem_waiver_cost`
+     - Premium-waiver cost lookup
+   * - ``ConstParams``
+     - :func:`~annuallife.TradLife_A.InputData.const_params`
+     - Scalar parameters used across the model
 
 .. _tradlife_a-basic-usage:
 
@@ -158,15 +275,45 @@ The plot scripts ``plot_tradlife_a.py`` and ``plot_pvcashflows_tradlife_a.py``
 in the library folder demonstrate how to produce stacked-bar charts of
 the cashflow components and their present values.
 
+Exporting the model
+^^^^^^^^^^^^^^^^^^^
+
+The model can be exported to a pure-Python (nomx) module that does not
+depend on modelx. Use the ``export`` method on the model object::
+
+    >>> m.export("TradLife_A_nomx")
+
+This command exports the model as a Python package named
+``TradLife_A_nomx`` in the current directory. You can test the exported
+(nomx) model by importing it and accessing its cells::
+
+    >>> from TradLife_A_nomx import mx_model
+
+    >>> mx_model.Projection[0].pv_net_cf(0)
+
+(Here, ``mx_model`` is the nomx model object.)
+
 Global References
 -----------------
 
+Global references are names that can be referenced from formulas in any
+space in the model. The third-party modules
+`pandas <https://pandas.pydata.org/>`__ and
+`numpy <https://numpy.org/>`__ are defined here, as are the enum types
+defined as child spaces under :mod:`~annuallife.TradLife_A.Enums`.
+
 Attributes:
-    pd: The :mod:`pandas` module.
-    np: The :mod:`numpy` module.
-    ProductID: Alias for :mod:`~annuallife.TradLife_A.Enums.ProductID`.
-    SexID: Alias for :mod:`~annuallife.TradLife_A.Enums.SexID`.
-    RateBasisID: Alias for :mod:`~annuallife.TradLife_A.Enums.RateBasisID`.
+    pd: The `pandas <https://pandas.pydata.org/>`__ module.
+    np: The `numpy <https://numpy.org/>`__ module.
+    ProductID: The product-type enum,
+        :mod:`~annuallife.TradLife_A.Enums.ProductID` (``TERM`` term
+        insurance, ``WL`` whole life, ``ENDW`` endowment).
+    SexID: The sex enum,
+        :mod:`~annuallife.TradLife_A.Enums.SexID` (``M`` male,
+        ``F`` female).
+    RateBasisID: The rate-basis enum,
+        :mod:`~annuallife.TradLife_A.Enums.RateBasisID` (``PREM`` premium
+        basis, ``VAL`` valuation basis).
 
 """
 


### PR DESCRIPTION
Closes #118.

## Summary

Reworks the `TradLife_A` module docstring (`lifelib/libraries/annuallife/TradLife_A/__init__.py`), which Sphinx autodoc renders as the model reference page, so it stands on its own and matches the annuallife Overview page reworked in #117.

## What changed

- **Overview**: removed the "successor of simplelife" framing and the legacy-equivalence example; aligned wording with #117 (annual new-business projection of term/whole-life/endowment products; liability cashflows: Premiums / Commissions and expenses / Claims; premiums via commutation functions; investment income reserves defined but not implemented). Added a **Computation flow** section: a space-wiring mermaid diagram plus a step-by-step narrative (input.xlsx → InputData → PolicyAttrs/Assumptions/Economic → CommTable → Projection → BaseProj/PV).
- **Model Structure**: space list converted to a `list-table`; child-spaces note kept after the table (no separate Composition heading). **Inheritance** subsection split into two described diagrams (Projection ← BaseProj/PV; Assumptions/PolicyAttrs ← Utilities). **Cross-space references** has its own diagram.
- **Input File**: table reordered to **External named range | Cells | Purpose**; "Cell" header fixed to "Cells".
- **Basic Usage**: added an **Exporting the model** subsection (`m.export("TradLife_A_nomx")` → `from TradLife_A_nomx import mx_model`), following the BasicTerm_SC house style.
- **Global References**: added prose explaining global references; `pandas`/`numpy` hyperlinked; enum entries expanded with member meanings and links to their `Enums` child spaces (Napoleon `Attributes:` retained for autodoc).

## Reviewer notes

- Documentation-only change; a single `.py` file is touched (docstring only, no formula/code changes).
- The structure diagrams intentionally **omit** the `PolicyAttrs.life_table` ↔ `CommTable.pol` cross-references, which are unused. Removing them from the model code is tracked separately in #119.
- Verified with an isolated Sphinx autodoc build (`-W`): all four mermaid diagrams and both tables render; the only warning is the pre-existing `:doc:\`/quickstart/index\`` cross-ref, a false positive outside the full docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)