### PR TITLE
Remove unused interface aliases from CommTable and PolicyAttrs

### DIFF
--- a/lifelib/libraries/annuallife/TradLife_A/CommTable/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/CommTable/__init__.py
@@ -39,7 +39,6 @@ Attributes:
 Attributes:
     mortality_tables: Alias for
         :func:`~annuallife.TradLife_A.InputData.mortality_tables`.
-    pol: Alias for :mod:`~annuallife.TradLife_A.PolicyAttrs`.
 
 Example:
 
@@ -231,5 +230,3 @@ IntRate = 0.01
 TableID = 1
 
 mortality_tables = ("Interface", ("..", "InputData", "mortality_tables"), "absolute")
-
-pol = ("Interface", ("..", "PolicyAttrs"), "auto")

--- a/lifelib/libraries/annuallife/TradLife_A/PolicyAttrs/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/PolicyAttrs/__init__.py
@@ -29,7 +29,6 @@ Attributes:
         :func:`~annuallife.TradLife_A.InputData.policy_data`,
         and product specs from
         :func:`~annuallife.TradLife_A.InputData.product_spec`.
-    life_table: Alias for :mod:`~annuallife.TradLife_A.CommTable`.
     prem_term: Alias for :func:`policy_term`.
     return_array(:obj:`bool`): When ``True`` (the default), helper
         functions inherited from
@@ -237,8 +236,6 @@ def surr_charge_param2():
 
 # ---------------------------------------------------------------------------
 # References
-
-life_table = ("Interface", ("..", "CommTable"), "auto")
 
 input_data = ("Interface", ("..", "InputData"), "auto")
 


### PR DESCRIPTION
## Summary
This PR removes unused interface alias definitions that were creating circular or unnecessary dependencies between modules in the TradLife_A model.

## Key Changes
- **CommTable/__init__.py**: Removed the `pol` alias that referenced `PolicyAttrs` module
- **PolicyAttrs/__init__.py**: Removed the `life_table` alias that referenced `CommTable` module
- Updated corresponding docstring references that documented these removed aliases

## Details
These interface aliases were not being utilized and created a circular dependency pattern between the CommTable and PolicyAttrs modules. Removing them simplifies the module structure and reduces unnecessary coupling while maintaining all functional behavior through the remaining interface definitions (`mortality_tables` and `input_data`).

https://claude.ai/code/session_01VRnrTZqz4DXnuiWKtjf8kB