### PR TITLE
Refactor reference definitions in TradLife_A projection spaces

### DIFF
--- a/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
@@ -30,7 +30,7 @@ Cells in this Space follow these naming conventions:
     cashflows. For example, ``claims_death(t)`` is the death benefit
     incurred between ``t`` and ``t+1``.
 
-The cells in this Space resolve their references through
+The following references are defined in this Space and inherited by
 :mod:`~annuallife.TradLife_A.Projection`:
 
 * ``pol`` -> :mod:`~annuallife.TradLife_A.PolicyAttrs`
@@ -628,3 +628,13 @@ def disc_rate_mth(t):
     return scen.disc_rate_mth(t)
 
 
+# ---------------------------------------------------------------------------
+# References
+
+scen = ("Interface", ("..", "Economic"), "auto")
+
+asmp = ("Interface", ("..", "Assumptions"), "auto")
+
+pol = ("Interface", ("..", "PolicyAttrs"), "auto")
+
+comm_table = ("Interface", ("..", "CommTable"), "auto")

--- a/lifelib/libraries/annuallife/TradLife_A/Projection/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Projection/__init__.py
@@ -34,8 +34,8 @@ Attributes:
 
 .. rubric:: References
 
-The following references are resolved in this Space and its base
-Spaces:
+The following references are inherited from
+:mod:`~annuallife.TradLife_A.BaseProj`:
 
 Attributes:
     pol: Alias for :mod:`~annuallife.TradLife_A.PolicyAttrs`.
@@ -57,14 +57,3 @@ _bases = [
 _allow_none = None
 
 _spaces = []
-
-# ---------------------------------------------------------------------------
-# References
-
-scen = ("Interface", ("..", "Economic"), "auto")
-
-asmp = ("Interface", ("..", "Assumptions"), "auto")
-
-pol = ("Interface", ("..", "PolicyAttrs"), "auto")
-
-comm_table = ("Interface", ("..", "CommTable"), "auto")


### PR DESCRIPTION
## Summary
Reorganized reference definitions in the TradLife_A model by moving shared interface references from the `Projection` space to the `BaseProj` space, establishing a clearer inheritance hierarchy.

## Key Changes
- **Moved reference definitions** from `Projection/__init__.py` to `BaseProj/__init__.py`:
  - `scen` (Economic interface)
  - `asmp` (Assumptions interface)
  - `pol` (PolicyAttrs interface)
  - `comm_table` (CommTable interface)

- **Updated documentation** in both spaces:
  - `BaseProj`: Changed description to indicate it defines references that are inherited by `Projection`
  - `Projection`: Updated to indicate references are inherited from `BaseProj` rather than being resolved locally

- **Removed redundant code** from `Projection/__init__.py` by eliminating the duplicate reference definitions

## Implementation Details
This refactoring establishes a clearer parent-child relationship where `BaseProj` serves as the authoritative source for common interface references, and `Projection` inherits these definitions. This reduces code duplication and makes the dependency structure more explicit and maintainable.

https://claude.ai/code/session_01G26EqZbKtsUcRwGX3UcN5o