### PR TITLE
DOC: Restructure TradLife_A.BaseProj documentation (#122)

### DIFF
--- a/doc/source/libraries/annuallife/BaseProj.rst
+++ b/doc/source/libraries/annuallife/BaseProj.rst
@@ -4,171 +4,42 @@ The **BaseProj** Space
 .. automodule:: annuallife.TradLife_A.BaseProj
 
 
-Formulas
--------------
-
-.. autosummary::
-
-   ~accum_cf
-   ~age
-   ~claims_acc_dth
-   ~claims_acc_hosp
-   ~claims_ann
-   ~claims_death
-   ~claims_living
-   ~claims_mat
-   ~claims_other
-   ~claims_sick_hosp
-   ~claims_surg
-   ~claims_surr
-   ~claims
-   ~change_rsrv
-   ~exps_acq
-   ~exps_acq_total
-   ~commissions_init
-   ~commissions_ren
-   ~commissions
-   ~exps_maint
-   ~exps_maint_total
-   ~exps_other
-   ~expenses
-   ~income_total
-   ~insur_if_beg1
-   ~insur_if_end
-   ~int_accum_cf
-   ~invst_income
-   ~net_cf
-   ~pols_acc_death
-   ~pols_acc_hosp
-   ~pols_annuity
-   ~pols_death
-   ~pols_if_aft_mat
-   ~pols_if_beg
-   ~pols_if_beg1
-   ~pols_if
-   ~pols_living
-   ~pols_maturity
-   ~pols_if_init
-   ~pols_other
-   ~pols_renewal
-   ~pols_sick_hosp
-   ~pols_surg
-   ~pols_lapse
-   ~premiums
-   ~profit_bef_tax
-   ~reserve_hosp_rsrv_end
-   ~reserve_prem_rsrv_end
-   ~reserve_total_end
-   ~reserve_uern_prem_end
-   ~ann_prem_pp
-   ~claims_acc_dth_pp
-   ~claims_acc_hosp_pp
-   ~claims_ann_pp
-   ~claims_death_pp
-   ~claims_living_pp
-   ~claims_mat_pp
-   ~claims_other_pp
-   ~claims_sick_hosp_pp
-   ~claims_surg_pp
-   ~claims_surr_pp
-   ~expense_acq_pp
-   ~commissions_init_pp
-   ~commissions_ren_pp
-   ~expense_maint_pp
-   ~exps_other_pp
-   ~invst_income_pp
-   ~premium_pp
-   ~reserve_prem_rsrv_aft_mat_pp
-   ~reserve_prem_rsrv_end_pp
-   ~reserve_total_aft_mat_pp
-   ~reserve_uern_prem_aft_mat_pp
-   ~reserve_uern_prem_end_pp
-   ~sum_assured
-   ~proj_len
-   ~mort_rate
-   ~gross_prem_rate
-   ~mort_factor
-   ~lapse_rate
-   ~ann_prem_rate
-   ~cash_value_rate
-   ~net_prem_rate
-   ~reserve_nlp_rate
-   ~surr_charge
-   ~last_mort_age
-   ~inflation_factor
-   ~disc_rate_mth
-
-
 Cells Descriptions
 ------------------
 
-.. autofunction:: accum_cf
+.. autofunction:: proj_len
 
 .. autofunction:: age
 
-.. autofunction:: claims_acc_dth
+.. autofunction:: last_mort_age
 
-.. autofunction:: claims_acc_hosp
+.. autofunction:: sum_assured
 
-.. autofunction:: claims_ann
+.. autofunction:: mort_rate
 
-.. autofunction:: claims_death
+.. autofunction:: mort_factor
 
-.. autofunction:: claims_living
+.. autofunction:: lapse_rate
 
-.. autofunction:: claims_mat
+.. autofunction:: gross_prem_rate
 
-.. autofunction:: claims_other
+.. autofunction:: ann_prem_rate
 
-.. autofunction:: claims_sick_hosp
+.. autofunction:: net_prem_rate
 
-.. autofunction:: claims_surg
+.. autofunction:: reserve_nlp_rate
 
-.. autofunction:: claims_surr
+.. autofunction:: cash_value_rate
 
-.. autofunction:: claims
+.. autofunction:: surr_charge
 
-.. autofunction:: change_rsrv
+.. autofunction:: inflation_factor
 
-.. autofunction:: exps_acq
+.. autofunction:: disc_rate_mth
 
-.. autofunction:: exps_acq_total
+.. autofunction:: pols_if_init
 
-.. autofunction:: commissions_init
-
-.. autofunction:: commissions_ren
-
-.. autofunction:: commissions
-
-.. autofunction:: exps_maint
-
-.. autofunction:: exps_maint_total
-
-.. autofunction:: exps_other
-
-.. autofunction:: expenses
-
-.. autofunction:: income_total
-
-.. autofunction:: insur_if_beg1
-
-.. autofunction:: insur_if_end
-
-.. autofunction:: int_accum_cf
-
-.. autofunction:: invst_income
-
-.. autofunction:: net_cf
-
-.. autofunction:: pols_acc_death
-
-.. autofunction:: pols_acc_hosp
-
-.. autofunction:: pols_annuity
-
-.. autofunction:: pols_death
-
-.. autofunction:: pols_if_aft_mat
+.. autofunction:: pols_renewal
 
 .. autofunction:: pols_if_beg
 
@@ -176,104 +47,138 @@ Cells Descriptions
 
 .. autofunction:: pols_if
 
-.. autofunction:: pols_living
+.. autofunction:: pols_if_aft_mat
+
+.. autofunction:: pols_death
+
+.. autofunction:: pols_lapse
 
 .. autofunction:: pols_maturity
 
-.. autofunction:: pols_if_init
+.. autofunction:: pols_annuity
 
-.. autofunction:: pols_other
+.. autofunction:: pols_living
 
-.. autofunction:: pols_renewal
+.. autofunction:: pols_acc_death
+
+.. autofunction:: pols_acc_hosp
 
 .. autofunction:: pols_sick_hosp
 
 .. autofunction:: pols_surg
 
-.. autofunction:: pols_lapse
+.. autofunction:: pols_other
 
-.. autofunction:: premiums
+.. autofunction:: claims
 
-.. autofunction:: profit_bef_tax
-
-.. autofunction:: reserve_hosp_rsrv_end
-
-.. autofunction:: reserve_prem_rsrv_end
-
-.. autofunction:: reserve_total_end
-
-.. autofunction:: reserve_uern_prem_end
-
-.. autofunction:: ann_prem_pp
-
-.. autofunction:: claims_acc_dth_pp
-
-.. autofunction:: claims_acc_hosp_pp
-
-.. autofunction:: claims_ann_pp
+.. autofunction:: claims_death
 
 .. autofunction:: claims_death_pp
 
-.. autofunction:: claims_living_pp
+.. autofunction:: claims_mat
 
 .. autofunction:: claims_mat_pp
 
-.. autofunction:: claims_other_pp
-
-.. autofunction:: claims_sick_hosp_pp
-
-.. autofunction:: claims_surg_pp
+.. autofunction:: claims_surr
 
 .. autofunction:: claims_surr_pp
 
-.. autofunction:: expense_acq_pp
+.. autofunction:: claims_ann
 
-.. autofunction:: commissions_init_pp
+.. autofunction:: claims_ann_pp
 
-.. autofunction:: commissions_ren_pp
+.. autofunction:: claims_acc_dth
 
-.. autofunction:: expense_maint_pp
+.. autofunction:: claims_acc_dth_pp
 
-.. autofunction:: exps_other_pp
+.. autofunction:: claims_acc_hosp
 
-.. autofunction:: invst_income_pp
+.. autofunction:: claims_acc_hosp_pp
+
+.. autofunction:: claims_sick_hosp
+
+.. autofunction:: claims_sick_hosp_pp
+
+.. autofunction:: claims_surg
+
+.. autofunction:: claims_surg_pp
+
+.. autofunction:: claims_living
+
+.. autofunction:: claims_living_pp
+
+.. autofunction:: claims_other
+
+.. autofunction:: claims_other_pp
+
+.. autofunction:: premiums
 
 .. autofunction:: premium_pp
 
-.. autofunction:: reserve_prem_rsrv_aft_mat_pp
+.. autofunction:: ann_prem_pp
+
+.. autofunction:: invst_income
+
+.. autofunction:: invst_income_pp
+
+.. autofunction:: income_total
+
+.. autofunction:: insur_if_beg1
+
+.. autofunction:: insur_if_end
+
+.. autofunction:: expenses
+
+.. autofunction:: exps_acq
+
+.. autofunction:: exps_acq_total
+
+.. autofunction:: expense_acq_pp
+
+.. autofunction:: exps_maint
+
+.. autofunction:: exps_maint_total
+
+.. autofunction:: expense_maint_pp
+
+.. autofunction:: exps_other
+
+.. autofunction:: exps_other_pp
+
+.. autofunction:: commissions
+
+.. autofunction:: commissions_init
+
+.. autofunction:: commissions_init_pp
+
+.. autofunction:: commissions_ren
+
+.. autofunction:: commissions_ren_pp
+
+.. autofunction:: reserve_prem_rsrv_end
 
 .. autofunction:: reserve_prem_rsrv_end_pp
 
-.. autofunction:: reserve_total_aft_mat_pp
+.. autofunction:: reserve_prem_rsrv_aft_mat_pp
 
-.. autofunction:: reserve_uern_prem_aft_mat_pp
+.. autofunction:: reserve_uern_prem_end
 
 .. autofunction:: reserve_uern_prem_end_pp
 
-.. autofunction:: sum_assured
+.. autofunction:: reserve_uern_prem_aft_mat_pp
 
-.. autofunction:: proj_len
+.. autofunction:: reserve_hosp_rsrv_end
 
-.. autofunction:: mort_rate
+.. autofunction:: reserve_total_end
 
-.. autofunction:: gross_prem_rate
+.. autofunction:: reserve_total_aft_mat_pp
 
-.. autofunction:: mort_factor
+.. autofunction:: change_rsrv
 
-.. autofunction:: lapse_rate
+.. autofunction:: net_cf
 
-.. autofunction:: ann_prem_rate
+.. autofunction:: accum_cf
 
-.. autofunction:: cash_value_rate
+.. autofunction:: int_accum_cf
 
-.. autofunction:: net_prem_rate
-
-.. autofunction:: reserve_nlp_rate
-
-.. autofunction:: surr_charge
-
-.. autofunction:: last_mort_age
-
-.. autofunction:: inflation_factor
-
-.. autofunction:: disc_rate_mth
+.. autofunction:: profit_bef_tax

--- a/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
@@ -3,32 +3,14 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
-"""Base Space for the :mod:`~annuallife.TradLife_A.Projection` Space.
+"""Core annual cashflow projection logic for a single traditional life policy.
 
-This Space serves as a base Space for
-:mod:`~annuallife.TradLife_A.Projection`,
-and it contains Cells for cashflow projection.
-
-Cells in this Space follow these naming conventions:
-
-``pols_``:
-    Cells whose names start with ``pols_`` deal with number of policies.
-    For example, ``pols_death(t)`` represents number of deaths between
-    time ``t`` and ``t+1``.
-
-``_pp``:
-    Cells whose names end with ``_pp`` represent an amount per policy.
-    For example, ``claims_death_pp`` represents the death benefit per
-    policy.
-
-``exps_``:
-    Cells whose names start with ``exps_`` represent expense cashflows.
-    For example, ``exps_maint`` means the maintenance expense cashflow.
-
-``claims_``:
-    Cells whose names start with ``claims_`` represent benefit
-    cashflows. For example, ``claims_death(t)`` is the death benefit
-    incurred between ``t`` and ``t+1``.
+This Space defines the period-by-period Cells that project policy
+decrement, benefits, premiums, commissions, expenses, investment
+income, reserves and the resulting net cashflow and profit for one
+model point. It is the base Space inherited by
+:mod:`~annuallife.TradLife_A.Projection`, which parameterizes these
+Cells by policy and scenario.
 
 The following references are defined in this Space and inherited by
 :mod:`~annuallife.TradLife_A.Projection`:
@@ -41,6 +23,230 @@ The following references are defined in this Space and inherited by
 The integer ``idx`` from the enclosing
 :mod:`~annuallife.TradLife_A.Projection` ItemSpace is used to index into
 the per-policy NumPy arrays returned by ``pol`` and ``asmp``.
+
+
+Cells Summary
+-------------
+
+Projection Parameters
+^^^^^^^^^^^^^^^^^^^^^
+
+Parameters that define the scope of the projection for the selected
+policy, such as its length and the attained age.
+
+.. autosummary::
+
+   ~proj_len
+   ~age
+   ~last_mort_age
+
+
+Assumptions
+^^^^^^^^^^^
+
+Cells that retrieve or derive the actuarial and economic assumptions
+applied to the selected policy: mortality, lapse, premium and reserve
+rates, surrender charge, inflation and discounting.
+
+.. autosummary::
+
+   ~mort_rate
+   ~mort_factor
+   ~lapse_rate
+   ~gross_prem_rate
+   ~ann_prem_rate
+   ~net_prem_rate
+   ~reserve_nlp_rate
+   ~cash_value_rate
+   ~surr_charge
+   ~inflation_factor
+   ~disc_rate_mth
+
+
+Policy Decrement
+^^^^^^^^^^^^^^^^
+
+The number of in-force policies and the movements (new business,
+death, surrender, maturity and rider exposures) that change it over
+the projection. Cells whose names start with ``pols_`` deal with
+numbers of policies.
+
+.. autosummary::
+
+   ~pols_if_init
+   ~pols_renewal
+   ~pols_if_beg
+   ~pols_if_beg1
+   ~pols_if
+   ~pols_if_aft_mat
+   ~pols_death
+   ~pols_lapse
+   ~pols_maturity
+   ~pols_annuity
+   ~pols_living
+   ~pols_acc_death
+   ~pols_acc_hosp
+   ~pols_sick_hosp
+   ~pols_surg
+   ~pols_other
+
+
+Policy Values
+^^^^^^^^^^^^^
+
+The sum assured for the selected policy and the insurance in force at
+the beginning and the end of the period.
+
+.. autosummary::
+
+   ~sum_assured
+   ~insur_if_beg1
+   ~insur_if_end
+
+
+Claims
+^^^^^^
+
+Aggregate benefit cashflows by cause, each shown together with its
+per-policy amount. Cells whose names start with ``claims_`` represent
+benefit cashflows for the period from ``t`` to ``t+1``, and those
+ending with ``_pp`` are the corresponding benefit per policy.
+
+.. autosummary::
+
+   ~claims
+   ~claims_death
+   ~claims_death_pp
+   ~claims_mat
+   ~claims_mat_pp
+   ~claims_surr
+   ~claims_surr_pp
+   ~claims_ann
+   ~claims_ann_pp
+   ~claims_acc_dth
+   ~claims_acc_dth_pp
+   ~claims_acc_hosp
+   ~claims_acc_hosp_pp
+   ~claims_sick_hosp
+   ~claims_sick_hosp_pp
+   ~claims_surg
+   ~claims_surg_pp
+   ~claims_living
+   ~claims_living_pp
+   ~claims_other
+   ~claims_other_pp
+
+
+Premiums
+^^^^^^^^
+
+Premium income with its per-policy and annualized amounts, and the
+total income for the period.
+
+.. autosummary::
+
+   ~premiums
+   ~premium_pp
+   ~ann_prem_pp
+   ~income_total
+
+
+Investment Income
+^^^^^^^^^^^^^^^^^
+
+Investment income earned on accumulated funds, with the corresponding
+per-policy amount.
+
+.. warning::
+
+   Investment income depends on reserve balances that are not yet
+   fully implemented (see the warning in the Reserves subsection);
+   the values produced are provisional and subject to change.
+
+.. autosummary::
+
+   ~invst_income
+   ~invst_income_pp
+
+
+Commissions and Expenses
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Acquisition, maintenance and other expense cashflows together with
+initial and renewal commissions, each with its per-policy amount.
+Cells whose names start with ``exps_`` represent expense cashflows.
+
+.. autosummary::
+
+   ~expenses
+   ~exps_acq
+   ~exps_acq_total
+   ~expense_acq_pp
+   ~exps_maint
+   ~exps_maint_total
+   ~expense_maint_pp
+   ~exps_other
+   ~exps_other_pp
+   ~commissions
+   ~commissions_init
+   ~commissions_init_pp
+   ~commissions_ren
+   ~commissions_ren_pp
+
+
+Reserves
+^^^^^^^^
+
+End-of-period reserve balances, their per-policy and after-maturity
+components, and the change in reserve over the period.
+
+.. warning::
+
+   Reserve calculations are not yet fully implemented. The
+   hospitalization reserve and the unearned premium reserve currently
+   return placeholder zeros and are to be implemented.
+
+.. autosummary::
+
+   ~reserve_prem_rsrv_end
+   ~reserve_prem_rsrv_end_pp
+   ~reserve_prem_rsrv_aft_mat_pp
+   ~reserve_uern_prem_end
+   ~reserve_uern_prem_end_pp
+   ~reserve_uern_prem_aft_mat_pp
+   ~reserve_hosp_rsrv_end
+   ~reserve_total_end
+   ~reserve_total_aft_mat_pp
+   ~change_rsrv
+
+
+Net Cashflows
+^^^^^^^^^^^^^
+
+The net liability cashflow and the accumulated cashflows with
+interest.
+
+.. autosummary::
+
+   ~net_cf
+   ~accum_cf
+   ~int_accum_cf
+
+
+Profits
+^^^^^^^
+
+Profit before tax for the period.
+
+.. warning::
+
+   Profit before tax depends on the change in reserves, which is not
+   yet fully implemented (see the warning in the Reserves subsection);
+   the values produced are provisional and subject to change.
+
+.. autosummary::
+
+   ~profit_bef_tax
 
 """
 


### PR DESCRIPTION
## Summary

Improves the documentation of the `annuallife.TradLife_A.BaseProj` modelx space, addressing #122.

- **"Cells Summary" moved into the `BaseProj/__init__.py` module docstring** (rendered via the existing `.. automodule::`). The previously flat ~88-entry autosummary is now split into grouped subsections, each with a short descriptive paragraph: Projection Parameters, Assumptions, Policy Decrement, Policy Values, Claims, Premiums, Investment Income, Commissions and Expenses, Reserves, Net Cashflows, Profits.
- **Per-policy (`_pp`) cells** are distributed next to their aggregate counterparts.
- **`.. warning::` admonitions** added to Reserves, Investment Income and Profits noting the not-yet-implemented state (hospitalization and unearned-premium reserves currently return placeholder zeros; investment income and profit before tax depend on them).
- **`BaseProj.rst`** trimmed to the title, `.. automodule::`, and the flat "Cells Descriptions" autofunction reference (reordered to follow the new group sequence).
- **Docstring opening rewritten** to concisely describe the space's central role instead of the redundant "base Space for ... base Space for" phrasing.

The full cell set is unchanged: 88 unique cells, with the docstring autosummary exactly matching the `BaseProj.rst` autofunction list.

## Why

#122 requested grouping the flat cells table by relevancy (modeled on `BasicTerm_S.rst`) and renaming the "Formulas" heading. Per follow-up direction, the grouped summary lives in the module docstring while the detailed reference stays in the `.rst`.

## Notes for reviewers

- `automodule` here is plain `sphinx.ext.autodoc` and `BaseProj/__init__.py` is an importable module, so section titles and directives in the module docstring render correctly — verified with a Sphinx build (no new `BaseProj` warnings).
- Judgment call: `income_total` (= premiums + investment income) had no clear home after the Premiums/Investment Income split and is placed under **Premiums** for now.
- Discussion and intermediate decisions are recorded in the comments on #122.

## Test plan

- [x] Sphinx HTML build completes (exit 0) with no new warnings referencing `BaseProj`
- [x] Rendered `BaseProj.html` shows all grouped subsections, the 3 warning admonitions, and "Cells Descriptions" with all 88 cells
- [x] Docstring autosummary cell set is identical to the `.rst` autofunction set (88 unique)

🤖 Generated with [Claude Code](https://claude.com/claude-code)