### PR TITLE
DOC: Restructure docstrings of remaining TradLife_A spaces

### DIFF
--- a/doc/source/libraries/annuallife/Assumptions.rst
+++ b/doc/source/libraries/annuallife/Assumptions.rst
@@ -4,36 +4,8 @@ The **Assumptions** Space
 .. automodule:: annuallife.TradLife_A.Assumptions
 
 
-Formulas
--------------
-
-.. autosummary::
-
-   ~cnsmp_tax
-   ~comm_init_prem
-   ~comm_ren_prem
-   ~comm_ren_term
-   ~exps_acq_ann_prem
-   ~exps_acq_pol
-   ~exps_acq_sa
-   ~exps_maint_ann_prem
-   ~exps_maint_pol
-   ~exps_maint_sa
-   ~inflation_rate
-   ~mortality_tables
-   ~mort_table_index
-   ~mort_array_index
-   ~last_mort_age
-   ~asmp_tables
-   ~mort_factor_index
-   ~lapse_rate_index
-   ~asmp_table_len
-
-
 Cells Descriptions
 ------------------
-
-.. autofunction:: cnsmp_tax
 
 .. autofunction:: comm_init_prem
 
@@ -52,6 +24,8 @@ Cells Descriptions
 .. autofunction:: exps_maint_pol
 
 .. autofunction:: exps_maint_sa
+
+.. autofunction:: cnsmp_tax
 
 .. autofunction:: inflation_rate
 

--- a/doc/source/libraries/annuallife/CommTable.rst
+++ b/doc/source/libraries/annuallife/CommTable.rst
@@ -4,54 +4,33 @@ The **CommTable** Space
 .. automodule:: annuallife.TradLife_A.CommTable
 
 
-Formulas
--------------
-
-.. autosummary::
-
-   ~AnnDuenx
-   ~AnnDuex
-   ~Ax
-   ~Axn
-   ~Cx
-   ~Dx
-   ~Exn
-   ~Mx
-   ~Nx
-   ~disc
-   ~dx
-   ~lx
-   ~qx
-   ~mortality_rates
-
-
 Cells Descriptions
 ------------------
 
-.. autofunction:: AnnDuenx
+.. autofunction:: lx
 
-.. autofunction:: AnnDuex
+.. autofunction:: dx
 
-.. autofunction:: Ax
+.. autofunction:: qx
 
-.. autofunction:: Axn
+.. autofunction:: mortality_rates
 
-.. autofunction:: Cx
+.. autofunction:: disc
 
 .. autofunction:: Dx
 
-.. autofunction:: Exn
+.. autofunction:: Cx
 
 .. autofunction:: Mx
 
 .. autofunction:: Nx
 
-.. autofunction:: disc
+.. autofunction:: Ax
 
-.. autofunction:: dx
+.. autofunction:: Axn
 
-.. autofunction:: lx
+.. autofunction:: Exn
 
-.. autofunction:: qx
+.. autofunction:: AnnDuenx
 
-.. autofunction:: mortality_rates
+.. autofunction:: AnnDuex

--- a/doc/source/libraries/annuallife/Economic.rst
+++ b/doc/source/libraries/annuallife/Economic.rst
@@ -4,15 +4,6 @@ The **Economic** Space
 .. automodule:: annuallife.TradLife_A.Economic
 
 
-Formulas
--------------
-
-.. autosummary::
-
-   ~disc_rate_mth
-   ~invst_ret_rate
-
-
 Cells Descriptions
 ------------------
 

--- a/doc/source/libraries/annuallife/InputData.rst
+++ b/doc/source/libraries/annuallife/InputData.rst
@@ -4,27 +4,6 @@ The **InputData** Space
 .. automodule:: annuallife.TradLife_A.InputData
 
 
-Formulas
--------------
-
-.. autosummary::
-
-   ~input_workbook
-   ~policy_data
-   ~mortality_tables
-   ~mort_table_last_ages
-   ~assumption_tables
-   ~scenarios
-   ~discount_rate
-   ~prem_waiver_cost
-   ~assumption
-   ~product_spec
-   ~const_params
-   ~get_named_range_as_df
-   ~get_named_range_as_dict
-   ~get_param_series
-
-
 Cells Descriptions
 ------------------
 
@@ -44,11 +23,11 @@ Cells Descriptions
 
 .. autofunction:: prem_waiver_cost
 
+.. autofunction:: const_params
+
 .. autofunction:: assumption
 
 .. autofunction:: product_spec
-
-.. autofunction:: const_params
 
 .. autofunction:: get_named_range_as_df
 

--- a/doc/source/libraries/annuallife/PV.rst
+++ b/doc/source/libraries/annuallife/PV.rst
@@ -4,31 +4,8 @@ The **PV** Space
 .. automodule:: annuallife.TradLife_A.PV
 
 
-Formulas
--------------
-
-.. autosummary::
-
-   ~interest_net_cf
-   ~pv_premiums
-   ~pv_claims_death
-   ~pv_claims_mat
-   ~pv_claims_surr
-   ~pv_claims
-   ~pv_exps_acq
-   ~pv_commissions
-   ~pv_exps_maint
-   ~pv_expenses
-   ~pv_net_cf
-   ~pv_net_cf_for_check
-   ~pv_check
-   ~pv_sum_insur_if
-
-
 Cells Descriptions
 ------------------
-
-.. autofunction:: interest_net_cf
 
 .. autofunction:: pv_premiums
 
@@ -49,6 +26,8 @@ Cells Descriptions
 .. autofunction:: pv_expenses
 
 .. autofunction:: pv_net_cf
+
+.. autofunction:: interest_net_cf
 
 .. autofunction:: pv_net_cf_for_check
 

--- a/doc/source/libraries/annuallife/PolicyAttrs.rst
+++ b/doc/source/libraries/annuallife/PolicyAttrs.rst
@@ -4,41 +4,6 @@ The **PolicyAttrs** Space
 .. automodule:: annuallife.TradLife_A.PolicyAttrs
 
 
-Formulas
--------------
-
-.. autosummary::
-
-   ~product
-   ~policy_type
-   ~sex
-   ~issue_age
-   ~prem_freq
-   ~policy_term
-   ~policy_count
-   ~sum_assured
-   ~gen
-   ~channel
-   ~duration
-   ~gross_prem_table
-   ~init_surr_charge
-   ~int_rate
-   ~load_acq_sa
-   ~load_maint_prem
-   ~load_maint_prem_waiver_prem
-   ~load_maint_sa
-   ~load_maint_sa2
-   ~reserve_rate
-   ~table_id
-   ~uern_prem_rate
-   ~load_acq_sa_param1
-   ~load_acq_sa_param2
-   ~load_maint_prem_param1
-   ~load_maint_prem_param2
-   ~surr_charge_param1
-   ~surr_charge_param2
-
-
 Cells Descriptions
 ------------------
 
@@ -64,15 +29,21 @@ Cells Descriptions
 
 .. autofunction:: duration
 
-.. autofunction:: gross_prem_table
-
-.. autofunction:: init_surr_charge
-
 .. autofunction:: int_rate
+
+.. autofunction:: table_id
 
 .. autofunction:: load_acq_sa
 
+.. autofunction:: load_acq_sa_param1
+
+.. autofunction:: load_acq_sa_param2
+
 .. autofunction:: load_maint_prem
+
+.. autofunction:: load_maint_prem_param1
+
+.. autofunction:: load_maint_prem_param2
 
 .. autofunction:: load_maint_prem_waiver_prem
 
@@ -80,20 +51,14 @@ Cells Descriptions
 
 .. autofunction:: load_maint_sa2
 
-.. autofunction:: reserve_rate
-
-.. autofunction:: table_id
-
-.. autofunction:: uern_prem_rate
-
-.. autofunction:: load_acq_sa_param1
-
-.. autofunction:: load_acq_sa_param2
-
-.. autofunction:: load_maint_prem_param1
-
-.. autofunction:: load_maint_prem_param2
+.. autofunction:: init_surr_charge
 
 .. autofunction:: surr_charge_param1
 
 .. autofunction:: surr_charge_param2
+
+.. autofunction:: gross_prem_table
+
+.. autofunction:: reserve_rate
+
+.. autofunction:: uern_prem_rate

--- a/doc/source/libraries/annuallife/Utilities.rst
+++ b/doc/source/libraries/annuallife/Utilities.rst
@@ -4,15 +4,6 @@ The **Utilities** Space
 .. automodule:: annuallife.TradLife_A.Utilities
 
 
-Formulas
--------------
-
-.. autosummary::
-
-   ~pandas_to_array
-   ~map_to_policies
-
-
 Cells Descriptions
 ------------------
 

--- a/lifelib/libraries/annuallife/TradLife_A/Assumptions/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Assumptions/__init__.py
@@ -15,7 +15,8 @@ into them with the integer policy index ``idx``. A few cells, such as
 :func:`asmp_tables` and :func:`mortality_tables`, return tables shared
 across all policies.
 
-.. rubric:: References
+Parameters and References
+-------------------------
 
 Attributes:
     input_data: Alias for :mod:`~annuallife.TradLife_A.InputData`.
@@ -42,6 +43,77 @@ Inherited from :mod:`~annuallife.TradLife_A.Utilities`:
 
 * :mod:`~annuallife.TradLife_A.Assumptions.AsmpID`: Enum-style codes
   identifying entries in the ``AsmpByDuration`` table.
+
+
+Cells Summary
+-------------
+
+Commission Assumptions
+^^^^^^^^^^^^^^^^^^^^^^
+
+Per-policy initial and renewal commission rates and the renewal
+commission term.
+
+.. autosummary::
+
+   ~comm_init_prem
+   ~comm_ren_prem
+   ~comm_ren_term
+
+
+Expense Assumptions
+^^^^^^^^^^^^^^^^^^^
+
+Per-policy acquisition and maintenance expense assumptions, expressed
+per annualized premium, per policy and per sum assured.
+
+.. autosummary::
+
+   ~exps_acq_ann_prem
+   ~exps_acq_pol
+   ~exps_acq_sa
+   ~exps_maint_ann_prem
+   ~exps_maint_pol
+   ~exps_maint_sa
+
+
+Tax and Inflation Assumptions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The consumption tax rate and the expense inflation rate.
+
+.. autosummary::
+
+   ~cnsmp_tax
+   ~inflation_rate
+
+
+Mortality
+^^^^^^^^^
+
+The mortality-table block and the per-policy indices that select each
+policy's base mortality rates and its last mortality age.
+
+.. autosummary::
+
+   ~mortality_tables
+   ~mort_table_index
+   ~mort_array_index
+   ~last_mort_age
+
+
+Mortality Factor and Lapse
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The assumption-by-duration table and the per-policy indices that
+select mortality factors and lapse rates, together with its row count.
+
+.. autosummary::
+
+   ~asmp_tables
+   ~mort_factor_index
+   ~lapse_rate_index
+   ~asmp_table_len
 
 """
 

--- a/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
@@ -16,13 +16,12 @@ Parameters and References
 -------------------------
 
 The following references are defined in this Space and inherited by
-:mod:`~annuallife.TradLife_A.Projection`.
+:mod:`~annuallife.TradLife_A.Projection`. The integer ``idx`` from the
+enclosing :mod:`~annuallife.TradLife_A.Projection` ItemSpace is used to
+index into the per-policy NumPy arrays returned by ``pol`` and
+``asmp``.
 
 Attributes:
-    idx(:obj:`int`): Policy index from the enclosing
-        :mod:`~annuallife.TradLife_A.Projection` ItemSpace, used to
-        index into the per-policy NumPy arrays returned by ``pol`` and
-        ``asmp``.
     pol: Alias for :mod:`~annuallife.TradLife_A.PolicyAttrs`.
     asmp: Alias for :mod:`~annuallife.TradLife_A.Assumptions`.
     scen: Alias for :mod:`~annuallife.TradLife_A.Economic`.

--- a/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
@@ -12,17 +12,21 @@ model point. It is the base Space inherited by
 :mod:`~annuallife.TradLife_A.Projection`, which parameterizes these
 Cells by policy and scenario.
 
+Parameters and References
+-------------------------
+
 The following references are defined in this Space and inherited by
-:mod:`~annuallife.TradLife_A.Projection`:
+:mod:`~annuallife.TradLife_A.Projection`.
 
-* ``pol`` -> :mod:`~annuallife.TradLife_A.PolicyAttrs`
-* ``asmp`` -> :mod:`~annuallife.TradLife_A.Assumptions`
-* ``scen`` -> :mod:`~annuallife.TradLife_A.Economic`
-* ``comm_table`` -> :mod:`~annuallife.TradLife_A.CommTable`
-
-The integer ``idx`` from the enclosing
-:mod:`~annuallife.TradLife_A.Projection` ItemSpace is used to index into
-the per-policy NumPy arrays returned by ``pol`` and ``asmp``.
+Attributes:
+    idx(:obj:`int`): Policy index from the enclosing
+        :mod:`~annuallife.TradLife_A.Projection` ItemSpace, used to
+        index into the per-policy NumPy arrays returned by ``pol`` and
+        ``asmp``.
+    pol: Alias for :mod:`~annuallife.TradLife_A.PolicyAttrs`.
+    asmp: Alias for :mod:`~annuallife.TradLife_A.Assumptions`.
+    scen: Alias for :mod:`~annuallife.TradLife_A.Economic`.
+    comm_table: Alias for :mod:`~annuallife.TradLife_A.CommTable`.
 
 
 Cells Summary

--- a/lifelib/libraries/annuallife/TradLife_A/CommTable/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/CommTable/__init__.py
@@ -13,7 +13,8 @@ Mortality tables are read from the ``MortalityTables`` range in
 :func:`~annuallife.TradLife_A.InputData.mortality_tables` and indexed
 through :func:`mortality_rates`.
 
-.. rubric:: Parameters
+Parameters and References
+-------------------------
 
 This Space is parameterized with :attr:`Sex`, :attr:`IntRate` and
 :attr:`TableID`::
@@ -50,6 +51,64 @@ Example:
 External Links:
     * `International actuarial notation by F.S.Perryman <https://www.casact.org/pubs/proceed/proceed49/49123.pdf>`_
     * `Actuarial notations on Wikipedia <https://en.wikipedia.org/wiki/Actuarial_notation>`_
+
+
+Cells Summary
+-------------
+
+Life Table
+^^^^^^^^^^
+
+The underlying life-table columns — survivors, deaths, mortality
+probability and the per-age mortality rates selected for this Space's
+sex and table.
+
+.. autosummary::
+
+   ~lx
+   ~dx
+   ~qx
+   ~mortality_rates
+
+
+Commutation Columns
+^^^^^^^^^^^^^^^^^^^
+
+The discount factor and the commutation columns :math:`D_x`,
+:math:`C_x`, :math:`M_x` and :math:`N_x` built from the life table.
+
+.. autosummary::
+
+   ~disc
+   ~Dx
+   ~Cx
+   ~Mx
+   ~Nx
+
+
+Assurances and Endowments
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Present values of whole-life and term assurances and of pure
+endowments.
+
+.. autosummary::
+
+   ~Ax
+   ~Axn
+   ~Exn
+
+
+Annuities
+^^^^^^^^^
+
+Present values of temporary and lifetime annuities-due, with optional
+split payments and deferment.
+
+.. autosummary::
+
+   ~AnnDuenx
+   ~AnnDuex
 
 """
 

--- a/lifelib/libraries/annuallife/TradLife_A/Economic/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Economic/__init__.py
@@ -3,12 +3,14 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
-"""Economic scenarios.
+"""Scenario economic rates for a single traditional life projection.
 
-The ``Economic`` Space provides economic assumptions, such as
-scenario interest rates used to discount cashflows.
+The ``Economic`` Space provides the per-scenario interest rates used
+to discount cashflows and to credit investment return, read from
+*input.xlsx*.
 
-.. rubric:: Parameters
+Parameters and References
+-------------------------
 
 ``Economic`` is parameterized with :attr:`scen_id`::
 
@@ -36,6 +38,18 @@ Example:
 
         >>> m.Economic[1].disc_rate_mth(0)
         0.015
+
+
+Cells Summary
+-------------
+
+The discount rate and the investment return rate for the selected
+scenario at time ``t``.
+
+.. autosummary::
+
+   ~disc_rate_mth
+   ~invst_ret_rate
 
 """
 

--- a/lifelib/libraries/annuallife/TradLife_A/InputData/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/InputData/__init__.py
@@ -30,13 +30,71 @@ The table below lists the cells and the Excel named ranges they read.
 :func:`const_params`           ``ConstParams``        Scalar parameters used across the model.
 ============================== =====================  ==========================================
 
-.. rubric:: References
+Parameters and References
+-------------------------
 
 Attributes:
     input_file_name(:obj:`str`): Name of the Excel workbook to read.
         Defaults to ``"input.xlsx"`` and is resolved relative to the
         parent directory of the model.
     openpyxl: The :mod:`openpyxl` module used to open the workbook.
+
+
+Cells Summary
+-------------
+
+Workbook
+^^^^^^^^
+
+Opens the Excel input workbook lazily; every other cell reads from it.
+
+.. autosummary::
+
+   ~input_workbook
+
+
+Input Tables
+^^^^^^^^^^^^
+
+Named ranges loaded as pandas objects: policy data, mortality and
+assumption tables, scenarios, discount and premium-waiver lookups and
+the scalar constants.
+
+.. autosummary::
+
+   ~policy_data
+   ~mortality_tables
+   ~mort_table_last_ages
+   ~assumption_tables
+   ~scenarios
+   ~discount_rate
+   ~prem_waiver_cost
+   ~const_params
+
+
+Lookups
+^^^^^^^
+
+Column lookups into the assumption and product-specification tables,
+keyed by the model point lookup levels.
+
+.. autosummary::
+
+   ~assumption
+   ~product_spec
+
+
+Helpers
+^^^^^^^
+
+Generic readers that turn a named range into a ``DataFrame``, a
+``dict`` or a keyed ``Series``.
+
+.. autosummary::
+
+   ~get_named_range_as_df
+   ~get_named_range_as_dict
+   ~get_param_series
 
 """
 

--- a/lifelib/libraries/annuallife/TradLife_A/PV/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/PV/__init__.py
@@ -3,12 +3,11 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
-"""Present Value mix-in Space
+"""Present values of the projected cashflows for a single traditional life policy.
 
-This Space serves as a base Space for
-:mod:`~annuallife.TradLife_A.Projection`,
-and it contains Cells that take the present value of projected
-cashflows produced by :mod:`~annuallife.TradLife_A.BaseProj`.
+This Space defines the Cells that discount the cashflows projected in
+:mod:`~annuallife.TradLife_A.BaseProj` back to time 0. It is one of the
+base Spaces inherited by :mod:`~annuallife.TradLife_A.Projection`.
 
 Each present-value cell is defined recursively in ``t``: the recursion
 terminates at ``t > proj_len()`` by returning ``0``, where
@@ -17,6 +16,71 @@ length for the selected policy. Discounting uses the
 :func:`~annuallife.TradLife_A.BaseProj.disc_rate_mth` cell that resolves
 to :func:`~annuallife.TradLife_A.Economic.disc_rate_mth` for the
 selected scenario.
+
+
+Cells Summary
+-------------
+
+Premiums and Claims
+^^^^^^^^^^^^^^^^^^^
+
+Present value of premium income and of the claim cashflows by cause.
+
+.. autosummary::
+
+   ~pv_premiums
+   ~pv_claims_death
+   ~pv_claims_mat
+   ~pv_claims_surr
+   ~pv_claims
+
+
+Expenses and Commissions
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Present value of acquisition, maintenance and total expenses and of
+commissions.
+
+.. autosummary::
+
+   ~pv_exps_acq
+   ~pv_commissions
+   ~pv_exps_maint
+   ~pv_expenses
+
+
+Net Cashflow
+^^^^^^^^^^^^
+
+Present value of the net liability cashflow and the interest accreted
+on it.
+
+.. autosummary::
+
+   ~pv_net_cf
+   ~interest_net_cf
+
+
+Validation
+^^^^^^^^^^
+
+An alternative recursive net-cashflow present value and the check
+that it agrees with :func:`pv_net_cf`.
+
+.. autosummary::
+
+   ~pv_net_cf_for_check
+   ~pv_check
+
+
+Exposure
+^^^^^^^^
+
+Present value of the insurance in force.
+
+.. autosummary::
+
+   ~pv_sum_insur_if
 
 """
 

--- a/lifelib/libraries/annuallife/TradLife_A/PolicyAttrs/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/PolicyAttrs/__init__.py
@@ -20,7 +20,8 @@ Most cells return per-policy NumPy arrays whose layout matches the rows
 of :func:`~annuallife.TradLife_A.InputData.policy_data`, so callers
 index into them with the integer policy index ``idx``.
 
-.. rubric:: References
+Parameters and References
+-------------------------
 
 Attributes:
     input_data: Alias for :mod:`~annuallife.TradLife_A.InputData`.
@@ -41,6 +42,93 @@ Inherited from :mod:`~annuallife.TradLife_A.Utilities`:
 
 * :func:`~annuallife.TradLife_A.Utilities.pandas_to_array`
 * :func:`~annuallife.TradLife_A.Utilities.map_to_policies`
+
+
+Cells Summary
+-------------
+
+Policy Attributes
+^^^^^^^^^^^^^^^^^
+
+Model point attributes read directly from
+:func:`~annuallife.TradLife_A.InputData.policy_data` for each policy.
+
+.. autosummary::
+
+   ~product
+   ~policy_type
+   ~sex
+   ~issue_age
+   ~prem_freq
+   ~policy_term
+   ~policy_count
+   ~sum_assured
+   ~gen
+   ~channel
+   ~duration
+
+
+Product Bases
+^^^^^^^^^^^^^
+
+Per-policy interest rate and mortality table identifiers, selected by
+rate basis (premium or valuation).
+
+.. autosummary::
+
+   ~int_rate
+   ~table_id
+
+
+Loadings
+^^^^^^^^
+
+Per-policy acquisition and maintenance loadings used by
+:func:`~annuallife.TradLife_A.BaseProj.gross_prem_rate`, together with
+the raw ``ProductSpecTable`` parameters they are built from.
+
+.. autosummary::
+
+   ~load_acq_sa
+   ~load_acq_sa_param1
+   ~load_acq_sa_param2
+   ~load_maint_prem
+   ~load_maint_prem_param1
+   ~load_maint_prem_param2
+   ~load_maint_prem_waiver_prem
+   ~load_maint_sa
+   ~load_maint_sa2
+
+
+Surrender Charges
+^^^^^^^^^^^^^^^^^
+
+The per-policy initial surrender charge rate and the raw
+``ProductSpecTable`` parameters it is built from.
+
+.. autosummary::
+
+   ~init_surr_charge
+   ~surr_charge_param1
+   ~surr_charge_param2
+
+
+Misc
+^^^^
+
+Placeholder cells reserved for future use.
+
+.. warning::
+
+   :func:`gross_prem_table`, :func:`reserve_rate` and
+   :func:`uern_prem_rate` are placeholders that currently return
+   ``None`` and are to be implemented.
+
+.. autosummary::
+
+   ~gross_prem_table
+   ~reserve_rate
+   ~uern_prem_rate
 
 """
 
@@ -162,16 +250,23 @@ def policy_type():
     return pandas_to_array(input_data.policy_data()['PolType'])
 
 
-gen = lambda: PolicyData[idx, 'Gen']
+def gen():
+    """Per-policy generation (cohort) identifier."""
+    return PolicyData[idx, 'Gen']
 
-channel = lambda: PolicyData[idx, 'Channel']
+
+def channel():
+    """Per-policy distribution channel."""
+    return PolicyData[idx, 'Channel']
 
 def sex():
     """Per-policy sex as a :mod:`~annuallife.TradLife_A.Enums.SexID` code."""
     return pandas_to_array(input_data.policy_data()['Sex'].map(lambda s: getattr(SexID, s)))
 
 
-duration = lambda: PolicyData[idx, 'Duration']
+def duration():
+    """Per-policy elapsed policy duration in years."""
+    return PolicyData[idx, 'Duration']
 
 def issue_age():
     """Per-policy issue age in years."""

--- a/lifelib/libraries/annuallife/TradLife_A/Projection/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Projection/__init__.py
@@ -3,9 +3,11 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
-"""Space for cashflow projection.
+"""Per-policy cashflow projection and present values for one model point and scenario.
 
-This Space is for projecting cashflows of individual model points.
+This is the user-facing Space of :mod:`~annuallife.TradLife_A`: each
+ItemSpace ``Projection[idx, scen_id]`` projects the cashflows and
+their present values for one policy under one scenario.
 
 .. rubric:: Inheritance Structure
 
@@ -16,7 +18,8 @@ The projection cells are inherited from
 :mod:`~annuallife.TradLife_A.BaseProj`, and the present values of those
 cashflow items are inherited from :mod:`~annuallife.TradLife_A.PV`.
 
-.. rubric:: Parameters
+Parameters and References
+-------------------------
 
 This Space is parameterized with ``idx`` and ``scen_id``::
 

--- a/lifelib/libraries/annuallife/TradLife_A/Utilities/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Utilities/__init__.py
@@ -16,6 +16,18 @@ The cells in this Space rely on a ``return_array`` reference, which is
 defined by the inheriting space (``True`` to convert results to NumPy
 arrays, ``False`` to keep them as pandas objects).
 
+
+Cells Summary
+-------------
+
+Helpers that convert pandas objects to per-policy NumPy arrays and
+reindex assumption tables onto the policy data.
+
+.. autosummary::
+
+   ~pandas_to_array
+   ~map_to_policies
+
 """
 
 from modelx.serialize.jsonvalues import *
@@ -39,6 +51,8 @@ def pandas_to_array(df_or_series):
     :mod:`~annuallife.TradLife_A.PolicyAttrs`), the input is converted
     via :meth:`~pandas.Series.to_numpy`. Otherwise the original pandas
     object is returned unchanged.
+
+    This is an uncached cell, so it is recomputed on every call.
     """
     return df_or_series.to_numpy() if return_array else df_or_series
 
@@ -54,6 +68,8 @@ def map_to_policies(series):
     ``PolType``, ``Gen``), and returns a Series whose index matches
     ``policy_data`` so it aligns with the per-policy NumPy arrays used
     elsewhere in the model.
+
+    This is an uncached cell, so it is recomputed on every call.
     """
     index_names = series.index.names
     target = input_data.policy_data()[index_names]


### PR DESCRIPTION
## Summary

Applies the BaseProj documentation pattern (#125) to the other **TradLife_A** spaces: PV, Assumptions, PolicyAttrs, CommTable, InputData, Economic, Utilities and Projection.

- **Grouped "Cells Summary" moved into each module docstring** (rendered via the existing `.. automodule::`), with Title-Case subsections (lowercase `and`) and short descriptive paragraphs. Each `.rst` is trimmed to title + `automodule` + a flat, reordered **Cells Descriptions**.
- **Vague opening lines rewritten** for PV, Economic and Projection to concisely state what the space does.
- **PolicyAttrs**: `gen`, `channel`, `duration` converted from lambdas to documented functions; cells regrouped into Policy Attributes / Product Bases / Loadings / Surrender Charges / Misc; `.. warning::` for the `None`-returning placeholders (`gross_prem_table`, `reserve_rate`, `uern_prem_rate`).
- **Utilities**: both helpers note they are uncached.
- **Assumptions / PV** group renames per review (Tax and Inflation Assumptions; Premiums and Claims).
- **Side-menu nesting fix**: each space's napoleon `Attributes:` block is now wrapped in a real reST section titled **"Parameters and References"**. `References`/`Parameters`/`Attributes` alone are napoleon keywords (rendered as rubrics, so their `py:attribute` objects floated to the top of the page TOC); the combined non-keyword heading stays a true section, so the objects nest under it. Applied to **BaseProj** too, so all eight pages have an identical clean three-entry side menu (`Parameters and References` → `Cells Summary` → `Cells Descriptions`).

## Why

Follow-up to #122/#125 to make the whole TradLife_A model documentation consistent and the page navigation clean.

## Notes for reviewers

- `automodule` is plain `sphinx.ext.autodoc`; `*/__init__.py` are importable modules, so section titles/directives in the docstrings render correctly.
- `py:attribute` objects are intentionally still generated — only their TOC placement changed.
- Judgment call carried over from #125: `income_total` stays under Premiums.

## Test plan

- [x] Sphinx HTML build exits 0 with no new warnings referencing these pages
- [x] Each space's docstring autosummary set equals its `.rst` autofunction set **and** the original set (PV 14, Assumptions 19, PolicyAttrs 28, CommTable 14, InputData 14, Economic 2, Utilities 2, BaseProj 88)
- [x] Side menu shows `Parameters and References` (attributes nested) → `Cells Summary` → `Cells Descriptions` on every page

🤖 Generated with [Claude Code](https://claude.com/claude-code)