### PR TITLE
DOC: List annuallife first in Libraries panel, table, and sidebar

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -112,6 +112,7 @@ Contribute your excellent work to lifelib and share it with actuaries from all a
 
    .. grid-item-card:: :doc:`Libraries<libraries/index>`
 
+      * :doc:`libraries/annuallife/index`
       * :doc:`libraries/basiclife/index`
       * :doc:`libraries/savings/index`
       * :doc:`libraries/appliedlife/index`

--- a/doc/source/libraries/index.rst
+++ b/doc/source/libraries/index.rst
@@ -13,10 +13,10 @@ independent of modelx using modelx's export feature.
    =============================== =============== ===============================================================
    Library                                         Contents
    =============================== =============== ===============================================================
+   :doc:`annuallife/index`         |modelx badge|  Annual projection model of basic traditional life policies
    :doc:`basiclife/index`          |modelx badge|  Basic life insurance cashflow models and examples
    :doc:`savings/index`            |modelx badge|  Cashflow models of saving products with cash values
    :doc:`appliedlife/index`        |modelx badge|  Comprehensive and practical projection model
-   :doc:`annuallife/index`         |modelx badge|  Annual projection model of basic traditional life policies
    :doc:`assets/index`             |modelx badge|  Basic models of bond portfolios
    :doc:`ifrs17a/index`                            IFRS17 calculation model and examples
    :doc:`economic/index`           |modelx badge|  Basic Hull-White model
@@ -29,10 +29,10 @@ independent of modelx using modelx's export feature.
    :maxdepth: 2
    :hidden:
 
+   annuallife/index.rst
    basiclife/index.rst
    savings/index.rst
    appliedlife/index.rst
-   annuallife/index.rst
    assets/index.rst
    ifrs17a/index.md
    economic/index.rst


### PR DESCRIPTION
## Summary

Surface the `annuallife` library more prominently in the docs by listing it first in three places:

- **Landing page Libraries panel** (`doc/source/index.rst`): `annuallife` was missing entirely — added as the first item.
- **Libraries page table** (`doc/source/libraries/index.rst`): moved from 4th row to the top.
- **Section Navigation sidebar** (`doc/source/libraries/index.rst` toctree): moved to first so it appears at the top of the sidebar on library pages.

## Verification

- Built the docs with Sphinx (pydata-sphinx-theme); build succeeds with exit code 0 and no new errors.
- Confirmed in the generated HTML that `annuallife` precedes `basiclife` in the landing-page panel, the Libraries table, and the Section Navigation sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)