### PR TITLE
DOC: Use UML inheritance arrows in TradLife_A Inheritance diagrams

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -276,5 +276,9 @@ panels_add_bootstrap_css = False
 # Fix mermaid
 nbsphinx_requirejs_path = ''
 
+# sphinxcontrib-mermaid defaults to 11.2.0; the class-diagram v3 renderer and
+# its hideEmptyMembersBox option require >= 11.4.0.
+mermaid_version = "11.4.1"
+
 def setup(app):
     app.add_css_file("custom-style.css")

--- a/lifelib/libraries/annuallife/TradLife_A/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/__init__.py
@@ -138,9 +138,10 @@ present-value counterparts share the same parameter scope.
 
 .. mermaid::
 
-    graph BT
-        BaseProj --> Projection
-        PV --> Projection
+    %%{init: {"class": {"hideEmptyMembersBox": true}}}%%
+    classDiagram
+        BaseProj <|-- Projection
+        PV <|-- Projection
 
 :mod:`~annuallife.TradLife_A.Assumptions` and
 :mod:`~annuallife.TradLife_A.PolicyAttrs` inherit from
@@ -149,9 +150,10 @@ present-value counterparts share the same parameter scope.
 
 .. mermaid::
 
-    graph BT
-        Utilities --> Assumptions
-        Utilities --> PolicyAttrs
+    %%{init: {"class": {"hideEmptyMembersBox": true}}}%%
+    classDiagram
+        Utilities <|-- Assumptions
+        Utilities <|-- PolicyAttrs
 
 Cross-space references
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

The two diagrams in the **Inheritance** section of the `TradLife_A` model
docstring (`lifelib/libraries/annuallife/TradLife_A/__init__.py`) previously
used Mermaid flowcharts (`graph BT` with plain `-->` arrows). They now use
`classDiagram` with `<|--` edges so the relationships render with the
**UML hollow-triangle generalization (inheritance) arrowhead**.

## Changes

- `lifelib/libraries/annuallife/TradLife_A/__init__.py` — both Inheritance
  diagrams converted to `classDiagram` + `<|--`. An
  `%%{init: {"class": {"hideEmptyMembersBox": true}}}%%` directive keeps the
  member-less classes rendering as plain rectangles (no empty member
  compartment), matching the original box appearance.
- `doc/source/conf.py` — pinned `mermaid_version = "11.4.1"`.

## Why the conf.py change is needed

`hideEmptyMembersBox` ships with Mermaid's class-diagram v3 renderer, first
released in **mermaid@11.4.0**. sphinxcontrib-mermaid defaults to
**11.2.0**, which silently ignores the option (the class boxes would show an
empty member compartment). Pinning 11.4.1 is a site-wide forward version
bump; existing flowchart/sequence/class diagrams render unchanged on 11.4.1.

The *Cross-space references* `graph LR` diagram further down is intentionally
left unchanged.

## Test plan

- [ ] Build the HTML docs (`make html` in `doc/`) — build succeeds
- [ ] Open `libraries/annuallife/TradLife_A.html`, hard-refresh, and confirm
      the two Inheritance diagrams show plain boxes with UML triangle
      arrowheads pointing to the base spaces (`BaseProj`/`PV`, `Utilities`)
- [ ] Confirm the *Cross-space references* diagram is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)