### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "modelx>=0.26.0",
@@ -94,7 +95,7 @@ markers = [
 
 [tool.black]
 line-length = 88
-target-version = ['py37', 'py38', 'py39', 'py310', 'py311', 'py312', 'py313']
+target-version = ['py37', 'py38', 'py39', 'py310', 'py311', 'py312', 'py313', 'py314']
 include = '\.pyi?$'
 extend-exclude = '''
 /(

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # and ensures consistency with the CI/CD pipeline.
 
 [tox]
-envlist = py{37,38,39,310,311,312,313}, lint, coverage
+envlist = py{37,38,39,310,311,312,313,314}, lint, coverage
 isolated_build = True
 skip_missing_interpreters = True
 


### PR DESCRIPTION
## Summary
This PR adds support for Python 3.14 across the project's configuration files and CI/CD pipeline.

## Key Changes
- Added Python 3.14 to the list of supported classifiers in `pyproject.toml`
- Updated Black's target version configuration to include `py314`
- Added Python 3.14 to the test matrix in GitHub Actions workflow
- Updated tox environment list to include `py314`

## Details
These changes ensure that:
- The package metadata correctly reflects Python 3.14 support
- Code formatting with Black targets Python 3.14 compatibility
- Automated tests run against Python 3.14 on all major platforms (Ubuntu, Windows, macOS)
- Local development with tox includes Python 3.14 testing

https://claude.ai/code/session_011JxFhvg656K62xHKM54fps