### PR TITLE
Add v0.12.0 release notes documentation

### DIFF
--- a/doc/source/releases/relnotes_v0.12.rst
+++ b/doc/source/releases/relnotes_v0.12.rst
@@ -1,0 +1,53 @@
+.. currentmodule:: lifelib.libraries
+
+==================================
+lifelib v0.12 Releases
+==================================
+
+To update lifelib, run the following command::
+
+    >>> pip install lifelib --upgrade
+
+If you're using Anaconda, use the ``conda`` command instead::
+
+    >>> conda update lifelib
+
+
+.. _relnotes_v0.12.0:
+
+lifelib v0.12.0 (17 May 2026)
+==================================
+
+New Library
+----------------
+
+This release adds a new library, :mod:`~annuallife`.
+:mod:`~annuallife` includes the :mod:`~annuallife.TradLife_A` model,
+a traditional life insurance projection model that works on an annual basis.
+See the :mod:`~annuallife` page for more details.
+
+Changes
+------------
+
+* lifelib projects have been migrated into the ``lifelib/libraries``
+  directory structure, unifying projects and libraries
+  (`GH92 <https://github.com/lifelib-dev/lifelib/pull/92>`_).
+
+* :mod:`~simplelife` and its dependent projects are now deprecated.
+  Deprecation notices are added to the affected models.
+
+* Python 3.14 is added to the supported Python versions, and
+  Python 3.7 and 3.8 are no longer supported.
+
+Fixes
+------------
+
+* Compatibility fixes for pandas 3.0, including ``select_dtypes``
+  string-dtype handling and chained-assignment ``fillna`` calls in
+  :mod:`~ifrs17a` Importers.
+
+* ``draw_charts`` and ``draw_waterfall`` are fixed to reflect a
+  modelx implementation change.
+
+* The Pandas4Warning raised by ``select_dtypes`` for string columns
+  is now silenced.

--- a/doc/source/updates.rst
+++ b/doc/source/updates.rst
@@ -14,6 +14,12 @@ Updates
     Follow <a href="https://www.linkedin.com/company/lifelib" target="_blank">lifelib on LinkedIn</a>
     for more frequent updates.</p>
 
+* *17 May 2026:*
+  lifelib :ref:`v0.12.0<relnotes_v0.12.0>` is released.
+  :mod:`~annuallife`, a new library featuring the
+  :mod:`~annuallife.TradLife_A` traditional life projection model, is added.
+  :mod:`~simplelife` and its dependent projects are now deprecated.
+
 * *10 Aug 2025:*
   New download available on the :doc:`download` page.
 

--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -33,6 +33,7 @@ Documentation for released versions of lifelib is available under
 .. toctree::
    :maxdepth: 1
 
+   releases/relnotes_v0.12
    releases/relnotes_v0.11
    releases/relnotes_v0.10
    releases/relnotes_v0.9.5


### PR DESCRIPTION
## Summary
This PR adds comprehensive release notes documentation for lifelib v0.12.0, including updates to the main documentation index pages.

## Key Changes
- **New release notes file** (`doc/source/releases/relnotes_v0.12.rst`): Comprehensive documentation of v0.12.0 changes including:
  - Introduction of the new `annuallife` library with `TradLife_A` model
  - Migration of projects into `lifelib/libraries` directory structure
  - Deprecation of `simplelife` and dependent projects
  - Python version support updates (added 3.14, dropped 3.7 and 3.8)
  - Compatibility fixes for pandas 3.0
  - Bug fixes for chart drawing functions

- **Updated `doc/source/updates.rst`**: Added entry for v0.12.0 release (17 May 2026) highlighting the new `annuallife` library and `simplelife` deprecation

- **Updated `doc/source/whatsnew.rst`**: Added reference to the new v0.12.0 release notes in the documentation index

## Notable Details
The release notes document significant structural changes to the lifelib project, including the unification of projects and libraries under a common directory structure and the introduction of a new traditional life insurance projection model.

https://claude.ai/code/session_01Qvr9sgxYyeCHCkL8w1F2zk