### PR TITLE
Require modelx>=0.31.0 and add serializer-v6 TradLife_A_mx30 copy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ Each project template is called a "library" and is designed to be easily extende
 ## Key Technologies
 
 - **Python**: 3.7+
-- **modelx**: Core dependency for model development (>=0.26.0)
+- **modelx**: Core dependency for model development (>=0.31.0)
 - **pandas**: Data manipulation
 - **numpy**: Numerical computations
 - **openpyxl**: Excel file handling

--- a/doc/source/libraries/annuallife/index.rst
+++ b/doc/source/libraries/annuallife/index.rst
@@ -74,6 +74,21 @@ are described in the
 :ref:`Basic Usage <tradlife_a-basic-usage>` section
 of the :mod:`~annuallife.TradLife_A` documentation.
 
+Older modelx versions
+^^^^^^^^^^^^^^^^^^^^^
+
+:mod:`~annuallife.TradLife_A` is saved in the modelx serializer
+version 7 format and requires **modelx v0.31.0 or newer**.
+
+For users whose ``modelx`` is older than v0.31.0, the library also
+includes ``TradLife_A_mx30``, a copy of :mod:`~annuallife.TradLife_A`
+saved in the older serializer version 6 format. It is the same model
+and reads its data from the same *input.xlsx*. Read it instead with::
+
+    >>> import modelx as mx
+
+    >>> m = mx.read_model("TradLife_A_mx30")
+
 
 Library Contents
 ------------------
@@ -93,6 +108,7 @@ Library Contents
    File or Folder                         Description
    ====================================== ==========================================================================
    ``TradLife_A``                         The :mod:`~annuallife.TradLife_A` model.
+   ``TradLife_A_mx30``                    Copy of :mod:`~annuallife.TradLife_A` saved in the modelx serializer version 6 format, for ``modelx`` older than v0.31.0.
    ``input.xlsx``                         Excel workbook holding policy data, assumptions, mortality tables, scenarios and product specs.
    ``plot_tradlife_a.py``                 sphinx-gallery plot script that renders the cashflow chart.
    ``plot_pvcashflows_tradlife_a.py``     sphinx-gallery plot script that renders present-value cashflows.

--- a/doc/source/releases/relnotes_v0.12.rst
+++ b/doc/source/releases/relnotes_v0.12.rst
@@ -39,6 +39,15 @@ Changes
 * Python 3.14 is added to the supported Python versions, and
   Python 3.7 and 3.8 are no longer supported.
 
+* lifelib now requires ``modelx`` v0.31.0 or newer, because
+  :mod:`~annuallife.TradLife_A` is saved in the modelx serializer
+  version 7 format introduced in modelx v0.31.0.
+
+* A copy of :mod:`~annuallife.TradLife_A` saved in the older serializer
+  version 6 format, ``TradLife_A_mx30``, is added to the
+  :mod:`~annuallife` library so that the model can still be read by
+  users whose ``modelx`` is older than v0.31.0.
+
 Fixes
 ------------
 

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/Assumptions/AsmpID/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/Assumptions/AsmpID/__init__.py
@@ -1,0 +1,53 @@
+"""Assumption table identifiers.
+
+Integer codes identifying columns of the ``AsmpByDuration`` table
+(loaded by :func:`~annuallife.TradLife_A.InputData.assumption_tables`).
+Each member corresponds to one duration-based assumption series:
+
+* ``MortAsmp1``, ``MortAsmp2`` - mortality-factor tables, picked up by
+  :func:`~annuallife.TradLife_A.Assumptions.mort_factor_index`.
+* ``Morb1`` ... ``Morb5`` - morbidity-factor tables (reserved for
+  benefit categories not currently exercised by the model).
+* ``LapseRate1`` - lapse-rate table, picked up by
+  :func:`~annuallife.TradLife_A.Assumptions.lapse_rate_index`.
+
+The numeric values reflect the column position in
+``AsmpByDuration``; consumers should refer to the names rather than the
+numbers.
+
+.. todo::
+
+   Split the combined duration table into per-type tables so that
+   morbidity, mortality factor and lapse rates each live in dedicated
+   ranges with self-explanatory member names.
+
+"""
+
+from modelx.serialize.jsonvalues import *
+
+_formula = None
+
+_bases = []
+
+_allow_none = None
+
+_spaces = []
+
+# ---------------------------------------------------------------------------
+# References
+
+MortAsmp1 = 1
+
+MortAsmp2 = 2
+
+Morb1 = 3
+
+Morb2 = 4
+
+Morb3 = 5
+
+Morb4 = 6
+
+Morb5 = 7
+
+LapseRate1 = 8

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/Assumptions/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/Assumptions/__init__.py
@@ -1,0 +1,291 @@
+"""Assumption input and calculations for individual policies.
+
+This Space holds assumption parameters and rates used by
+:mod:`~annuallife.TradLife_A.Projection` and its base spaces.
+
+Most cells in this Space return per-policy NumPy arrays whose layout
+matches the rows of
+:func:`~annuallife.TradLife_A.InputData.policy_data`, so callers index
+into them with the integer policy index ``idx``. A few cells, such as
+:func:`asmp_tables` and :func:`mortality_tables`, return tables shared
+across all policies.
+
+Parameters and References
+-------------------------
+
+Attributes:
+    input_data: Alias for :mod:`~annuallife.TradLife_A.InputData`.
+        Per-policy assumptions are read from the ``AssumptionTable``
+        range in *input.xlsx* via
+        :func:`~annuallife.TradLife_A.InputData.assumption`,
+        and mortality / lapse tables from
+        :func:`~annuallife.TradLife_A.InputData.assumption_tables` and
+        :func:`~annuallife.TradLife_A.InputData.mortality_tables`.
+
+    return_array(:obj:`bool`): When ``True`` (the default), helper
+        functions inherited from
+        :mod:`~annuallife.TradLife_A.Utilities` return NumPy arrays
+        instead of pandas objects.
+
+.. rubric:: Inherited helpers
+
+Inherited from :mod:`~annuallife.TradLife_A.Utilities`:
+
+* :func:`~annuallife.TradLife_A.Utilities.pandas_to_array`
+* :func:`~annuallife.TradLife_A.Utilities.map_to_policies`
+
+.. rubric:: Child spaces
+
+* :mod:`~annuallife.TradLife_A.Assumptions.AsmpID`: Enum-style codes
+  identifying entries in the ``AsmpByDuration`` table.
+
+
+Cells Summary
+-------------
+
+Commission Assumptions
+^^^^^^^^^^^^^^^^^^^^^^
+
+Per-policy initial and renewal commission rates and the renewal
+commission term.
+
+.. autosummary::
+
+   ~comm_init_prem
+   ~comm_ren_prem
+   ~comm_ren_term
+
+
+Expense Assumptions
+^^^^^^^^^^^^^^^^^^^
+
+Per-policy acquisition and maintenance expense assumptions, expressed
+per annualized premium, per policy and per sum assured.
+
+.. autosummary::
+
+   ~exps_acq_ann_prem
+   ~exps_acq_pol
+   ~exps_acq_sa
+   ~exps_maint_ann_prem
+   ~exps_maint_pol
+   ~exps_maint_sa
+
+
+Tax and Inflation Assumptions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The consumption tax rate and the expense inflation rate.
+
+.. autosummary::
+
+   ~cnsmp_tax
+   ~inflation_rate
+
+
+Mortality
+^^^^^^^^^
+
+The mortality-table block and the per-policy indices that select each
+policy's base mortality rates and its last mortality age.
+
+.. autosummary::
+
+   ~mortality_tables
+   ~mort_table_index
+   ~mort_array_index
+   ~last_mort_age
+
+
+Mortality Factor and Lapse
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The assumption-by-duration table and the per-policy indices that
+select mortality factors and lapse rates, together with its row count.
+
+.. autosummary::
+
+   ~asmp_tables
+   ~mort_factor_index
+   ~lapse_rate_index
+   ~asmp_table_len
+
+"""
+
+from modelx.serialize.jsonvalues import *
+
+_formula = None
+
+_bases = [
+    ".Utilities"
+]
+
+_allow_none = None
+
+_spaces = [
+    "AsmpID"
+]
+
+# ---------------------------------------------------------------------------
+# Cells
+
+def cnsmp_tax():
+    """Consumption tax rate"""
+    return input_data.const_params()['CnsmpTax']
+
+
+def comm_init_prem():
+    """Initial commission per premium"""
+    return pandas_to_array(map_to_policies(input_data.assumption('CommInitPrem')))
+
+
+def comm_ren_prem():
+    """Renewal commission per premium"""
+    return pandas_to_array(map_to_policies(input_data.assumption('CommRenPrem')))
+
+
+def comm_ren_term():
+    """Renewal commission term"""
+    return pandas_to_array(map_to_policies(input_data.assumption('CommRenTerm')))
+
+
+def exps_acq_ann_prem():
+    """Acquisition expense per annualized premium"""
+    return pandas_to_array(map_to_policies(input_data.assumption('ExpsAcqAnnPrem')))
+
+
+def exps_acq_pol():
+    """Acquisition expense per policy"""
+    return pandas_to_array(map_to_policies(input_data.assumption('ExpsAcqPol')))
+
+
+def exps_acq_sa():
+    """Acquisition expense per sum assured"""
+    return pandas_to_array(map_to_policies(input_data.assumption('ExpsAcqSA')))
+
+
+def exps_maint_ann_prem():
+    """Maintenance expense per annualized premium"""
+    return pandas_to_array(map_to_policies(input_data.assumption('ExpsMaintPrem')))
+
+
+def exps_maint_pol():
+    """Maintenance expense per policy"""
+    return pandas_to_array(map_to_policies(input_data.assumption('ExpsMaintPol')))
+
+
+def exps_maint_sa():
+    """Maintenance expense per sum assured"""
+    return pandas_to_array(map_to_policies(input_data.assumption('ExpsMaintSA')))
+
+
+def inflation_rate():
+    """Inflation rate"""
+    return input_data.const_params()['InflRate']
+
+
+def mortality_tables():
+    """Mortality tables read from *input.xlsx*.
+
+    Returns the full mortality-table block from the ``MortalityTables``
+    range as a 2-D NumPy array (when ``return_array`` is ``True``),
+    where rows are indexed by age and columns by ``(MortTable, Sex)``.
+    """
+
+    tables = input_data.mortality_tables()
+    return pandas_to_array(tables)
+
+
+def mort_table_index():
+    """Per-policy mortality table identifier.
+
+    Maps the ``BaseMort`` assumption keyed by the model point lookup
+    (product, policy type, gen) to each row of
+    :func:`~annuallife.TradLife_A.InputData.policy_data`.
+    """
+    return map_to_policies(input_data.assumption('BaseMort'))
+
+
+def mort_array_index():
+    """Per-policy column index into :func:`mortality_tables`.
+
+    Returns a 1-D integer array of column positions in
+    :func:`~annuallife.TradLife_A.InputData.mortality_tables` for each
+    policy's ``(mort_table_index, sex)`` pair.
+    """
+
+    columns = input_data.mortality_tables().columns
+
+    # Get the column positions in input_data.mortality_tables for each (MortID, sex) pair
+    return columns.get_indexer(
+        pd.MultiIndex.from_arrays([mort_table_index(), input_data.policy_data()['Sex']])
+    )
+
+
+def last_mort_age():
+    """Last mortality age per policy (first age where mortality reaches 1)."""
+
+    last_ages = input_data.mort_table_last_ages()
+    keys = pd.MultiIndex.from_arrays(
+        [mort_table_index(), input_data.policy_data()['Sex']]
+    )
+    result = pd.Series(last_ages.reindex(keys).values,
+                       index=input_data.policy_data().index)
+    return pandas_to_array(result)
+
+
+def asmp_tables():
+    """Assumption tables by duration.
+
+    Returns the ``AsmpByDuration`` range from *input.xlsx* as a 2-D
+    NumPy array indexed by duration (rows) and assumption ID (columns).
+    Used by :func:`~annuallife.TradLife_A.BaseProj.mort_factor` and
+    :func:`~annuallife.TradLife_A.BaseProj.lapse_rate` together with
+    :func:`mort_factor_index` and :func:`lapse_rate_index`.
+    """
+    return pandas_to_array(input_data.assumption_tables())
+
+
+def mort_factor_index():
+    """Per-policy column index into :func:`asmp_tables` for mortality factors.
+
+    Resolves each policy's ``MortFactor`` assumption (referencing an
+    :mod:`~annuallife.TradLife_A.Assumptions.AsmpID`) to its column
+    position in the ``AsmpByDuration`` table.
+    """
+
+
+    key_to_idx = {getattr(AsmpID, v): i for i, v in enumerate(input_data.assumption_tables().columns)}
+
+    indexes = input_data.assumption('MortFactor').map(lambda s: getattr(AsmpID, s)).map(key_to_idx)
+
+    return pandas_to_array(map_to_policies(indexes))
+
+
+def lapse_rate_index():
+    """Per-policy column index into :func:`asmp_tables` for lapse rates.
+
+    Resolves each policy's ``Surrender`` assumption (referencing an
+    :mod:`~annuallife.TradLife_A.Assumptions.AsmpID`) to its column
+    position in the ``AsmpByDuration`` table.
+    """
+
+
+    key_to_idx = {getattr(AsmpID, v): i for i, v in enumerate(input_data.assumption_tables().columns)}
+
+    indexes = input_data.assumption('Surrender').map(lambda s: getattr(AsmpID, s)).map(key_to_idx)
+
+    return pandas_to_array(map_to_policies(indexes))
+
+
+def asmp_table_len():
+    """Number of rows (durations) in :func:`asmp_tables`."""
+    return len(asmp_tables())
+
+
+# ---------------------------------------------------------------------------
+# References
+
+input_data = ("Interface", ("..", "InputData"), "auto")
+
+return_array = True

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/BaseProj/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/BaseProj/__init__.py
@@ -1,0 +1,844 @@
+"""Core annual cashflow projection logic for a single traditional life policy.
+
+This Space defines the period-by-period Cells that project policy
+decrement, benefits, premiums, commissions, expenses, investment
+income, reserves and the resulting net cashflow and profit for one
+model point. It is the base Space inherited by
+:mod:`~annuallife.TradLife_A.Projection`, which parameterizes these
+Cells by policy and scenario.
+
+Parameters and References
+-------------------------
+
+The following references are defined in this Space and inherited by
+:mod:`~annuallife.TradLife_A.Projection`. The integer ``idx`` from the
+enclosing :mod:`~annuallife.TradLife_A.Projection` ItemSpace is used to
+index into the per-policy NumPy arrays returned by ``pol`` and
+``asmp``.
+
+Attributes:
+    pol: Alias for :mod:`~annuallife.TradLife_A.PolicyAttrs`.
+    asmp: Alias for :mod:`~annuallife.TradLife_A.Assumptions`.
+    scen: Alias for :mod:`~annuallife.TradLife_A.Economic`.
+    comm_table: Alias for :mod:`~annuallife.TradLife_A.CommTable`.
+
+
+Cells Summary
+-------------
+
+Projection Parameters
+^^^^^^^^^^^^^^^^^^^^^
+
+Parameters that define the scope of the projection for the selected
+policy, such as its length and the attained age.
+
+.. autosummary::
+
+   ~proj_len
+   ~age
+   ~last_mort_age
+
+
+Assumptions
+^^^^^^^^^^^
+
+Cells that retrieve or derive the actuarial and economic assumptions
+applied to the selected policy: mortality, lapse, premium and reserve
+rates, surrender charge, inflation and discounting.
+
+.. autosummary::
+
+   ~mort_rate
+   ~mort_factor
+   ~lapse_rate
+   ~gross_prem_rate
+   ~ann_prem_rate
+   ~net_prem_rate
+   ~reserve_nlp_rate
+   ~cash_value_rate
+   ~surr_charge
+   ~inflation_factor
+   ~disc_rate_mth
+
+
+Policy Decrement
+^^^^^^^^^^^^^^^^
+
+The number of in-force policies and the movements (new business,
+death, surrender, maturity and rider exposures) that change it over
+the projection. Cells whose names start with ``pols_`` deal with
+numbers of policies.
+
+.. autosummary::
+
+   ~pols_if_init
+   ~pols_renewal
+   ~pols_if_beg
+   ~pols_if_beg1
+   ~pols_if
+   ~pols_if_aft_mat
+   ~pols_death
+   ~pols_lapse
+   ~pols_maturity
+   ~pols_annuity
+   ~pols_living
+   ~pols_acc_death
+   ~pols_acc_hosp
+   ~pols_sick_hosp
+   ~pols_surg
+   ~pols_other
+
+
+Policy Values
+^^^^^^^^^^^^^
+
+The sum assured for the selected policy and the insurance in force at
+the beginning and the end of the period.
+
+.. autosummary::
+
+   ~sum_assured
+   ~insur_if_beg1
+   ~insur_if_end
+
+
+Claims
+^^^^^^
+
+Aggregate benefit cashflows by cause, each shown together with its
+per-policy amount. Cells whose names start with ``claims_`` represent
+benefit cashflows for the period from ``t`` to ``t+1``, and those
+ending with ``_pp`` are the corresponding benefit per policy.
+
+.. autosummary::
+
+   ~claims
+   ~claims_death
+   ~claims_death_pp
+   ~claims_mat
+   ~claims_mat_pp
+   ~claims_surr
+   ~claims_surr_pp
+   ~claims_ann
+   ~claims_ann_pp
+   ~claims_acc_dth
+   ~claims_acc_dth_pp
+   ~claims_acc_hosp
+   ~claims_acc_hosp_pp
+   ~claims_sick_hosp
+   ~claims_sick_hosp_pp
+   ~claims_surg
+   ~claims_surg_pp
+   ~claims_living
+   ~claims_living_pp
+   ~claims_other
+   ~claims_other_pp
+
+
+Premiums
+^^^^^^^^
+
+Premium income with its per-policy and annualized amounts, and the
+total income for the period.
+
+.. autosummary::
+
+   ~premiums
+   ~premium_pp
+   ~ann_prem_pp
+   ~income_total
+
+
+Investment Income
+^^^^^^^^^^^^^^^^^
+
+Investment income earned on accumulated funds, with the corresponding
+per-policy amount.
+
+.. warning::
+
+   Investment income depends on reserve balances that are not yet
+   fully implemented (see the warning in the Reserves subsection);
+   the values produced are provisional and subject to change.
+
+.. autosummary::
+
+   ~invst_income
+   ~invst_income_pp
+
+
+Commissions and Expenses
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Acquisition, maintenance and other expense cashflows together with
+initial and renewal commissions, each with its per-policy amount.
+Cells whose names start with ``exps_`` represent expense cashflows.
+
+.. autosummary::
+
+   ~expenses
+   ~exps_acq
+   ~exps_acq_total
+   ~expense_acq_pp
+   ~exps_maint
+   ~exps_maint_total
+   ~expense_maint_pp
+   ~exps_other
+   ~exps_other_pp
+   ~commissions
+   ~commissions_init
+   ~commissions_init_pp
+   ~commissions_ren
+   ~commissions_ren_pp
+
+
+Reserves
+^^^^^^^^
+
+End-of-period reserve balances, their per-policy and after-maturity
+components, and the change in reserve over the period.
+
+.. warning::
+
+   Reserve calculations are not yet fully implemented. The
+   hospitalization reserve and the unearned premium reserve currently
+   return placeholder zeros and are to be implemented.
+
+.. autosummary::
+
+   ~reserve_prem_rsrv_end
+   ~reserve_prem_rsrv_end_pp
+   ~reserve_prem_rsrv_aft_mat_pp
+   ~reserve_uern_prem_end
+   ~reserve_uern_prem_end_pp
+   ~reserve_uern_prem_aft_mat_pp
+   ~reserve_hosp_rsrv_end
+   ~reserve_total_end
+   ~reserve_total_aft_mat_pp
+   ~change_rsrv
+
+
+Net Cashflows
+^^^^^^^^^^^^^
+
+The net liability cashflow and the accumulated cashflows with
+interest.
+
+.. autosummary::
+
+   ~net_cf
+   ~accum_cf
+   ~int_accum_cf
+
+
+Profits
+^^^^^^^
+
+Profit before tax for the period.
+
+.. warning::
+
+   Profit before tax depends on the change in reserves, which is not
+   yet fully implemented (see the warning in the Reserves subsection);
+   the values produced are provisional and subject to change.
+
+.. autosummary::
+
+   ~profit_bef_tax
+
+"""
+
+from modelx.serialize.jsonvalues import *
+
+_formula = None
+
+_bases = []
+
+_allow_none = None
+
+_spaces = []
+
+# ---------------------------------------------------------------------------
+# Cells
+
+def accum_cf(t):
+    """Accumulated cashflows"""
+    if t == 0:
+        return 0
+    else:
+        return (accum_cf(t-1)
+                + int_accum_cf(t-1)
+                + net_cf(t-1))
+
+
+def age(t):
+    """Attained age at time ``t``"""
+    return pol.issue_age()[idx] + t
+
+
+def claims_acc_dth(t):
+    """Accidental death benefits"""
+    return claims_acc_dth_pp(t) * pols_acc_death(t)
+
+
+def claims_acc_hosp(t):
+    """Accidental hospitalization benefits"""
+    return claims_acc_hosp_pp(t) * pols_acc_hosp(t)
+
+
+def claims_ann(t):
+    """Annuity benefits"""
+    return claims_ann_pp(t) * pols_annuity(t)
+
+
+def claims_death(t):
+    """Death benefits"""
+    return claims_death_pp(t) * pols_death(t)
+
+
+def claims_living(t):
+    """Living benefits"""
+    return claims_living_pp(t) * pols_living(t)
+
+
+def claims_mat(t):
+    """Maturity benefits"""
+    return claims_mat_pp(t) * pols_maturity(t)
+
+
+def claims_other(t):
+    """Other benefits"""
+    return claims_other_pp(t) * pols_other(t)
+
+
+def claims_sick_hosp(t):
+    """Sickness hospitalization benefits"""
+    return claims_sick_hosp_pp(t) * pols_sick_hosp(t)
+
+
+def claims_surg(t):
+    """Surgery benefits"""
+    return claims_surg_pp(t) * pols_surg(t)
+
+
+def claims_surr(t):
+    """Surrender benefits"""
+    return claims_surr_pp(t) * pols_lapse(t)
+
+
+def claims(t):
+    """Total benefits"""
+    return (claims_mat(t)
+            + claims_death(t)
+            + claims_acc_dth(t)
+            + claims_surr(t)
+            + claims_ann(t)
+            + claims_acc_hosp(t)
+            + claims_sick_hosp(t)
+            + claims_surg(t)
+            + claims_living(t)
+            + claims_other(t))
+
+
+def change_rsrv(t):
+    """Change in reserve"""
+    return reserve_total_end(t+1) - reserve_total_end(t)
+
+
+def exps_acq(t):
+    """Acquisition expenses"""
+    return expense_acq_pp(t) * (pols_if_init(t) + pols_renewal(t))
+
+
+def exps_acq_total(t):
+    """Commissions and acquisition expenses"""
+    return commissions(t) + exps_acq(t)
+
+
+def commissions_init(t):
+    """Initial commissions"""
+    return commissions_init_pp(t) * pols_if_beg1(t)
+
+
+def commissions_ren(t):
+    """Renewal commissions"""
+    return commissions_ren_pp(t) * pols_if_beg1(t)
+
+
+def commissions(t):
+    """Commissions Total"""
+    return commissions_init(t) + commissions_ren(t)
+
+
+def exps_maint(t):
+    """Maintenance expenses"""
+    return expense_maint_pp(t) * pols_if_beg1(t)
+
+
+def exps_maint_total(t):
+    """Total maintenance expenses including other expenses"""
+    return exps_maint(t) + exps_other(t)
+
+
+def exps_other(t):
+    """Other expenses"""
+    return 0
+
+
+def expenses(t):
+    """Total expenses"""
+    return (commissions_init(t)
+            + commissions_ren(t)
+            + exps_acq(t)
+            + exps_maint(t)
+            + exps_other(t))
+
+
+def income_total(t):
+    """Income Total"""
+    return premiums(t) + invst_income(t)
+
+
+def insur_if_beg1(t):
+    """Insurance in-force: Beginning of period 1"""
+    return pols_if_beg1(t) * sum_assured(t)
+
+
+def insur_if_end(t):
+    """Insurance in-force: End of period"""
+    return pols_if(t) * sum_assured(t)
+
+
+def int_accum_cf(t):
+    """Interest on accumulated cashflows"""
+    return (accum_cf(t)
+            + premiums(t)
+            - expenses(t)) * disc_rate_mth(t)
+
+
+def invst_income(t):
+    """Investment income"""
+    return invst_income_pp(t) * pols_if_beg1(t)
+
+
+def net_cf(t):
+    """Net liability cashflow"""
+    return (premiums(t)
+            - claims(t)
+            - expenses(t))
+
+
+def pols_acc_death(t):
+    """Number of policies: Accidental death"""
+    return 0
+
+
+def pols_acc_hosp(t):
+    """Number of policies: Accidental Hospitalization"""
+    return 0
+
+
+def pols_annuity(t):
+    """Number of policies: Annuity"""
+    return 0
+
+
+def pols_death(t):
+    """Number of policies: Death"""
+    return pols_if_beg1(t) * mort_rate(age(t)) * mort_factor(t)
+
+
+def pols_if_aft_mat(t):
+    """Number of policies: After maturity"""
+    return pols_if(t) - pols_maturity(t)
+
+
+def pols_if_beg(t):
+    """Number of policies: Beginning of period"""
+    return pols_if_aft_mat(t)
+
+
+def pols_if_beg1(t):
+    """Number of policies: Beginning of period 1"""
+    return pols_if_beg(t) + pols_renewal(t) + pols_if_init(t)
+
+
+def pols_if(t):
+    """Number of policies: End of period"""
+    if t == 0:
+        return 0 # pol.policy_count
+    else:
+        return pols_if_beg1(t-1) - pols_death(t-1) - pols_lapse(t-1)
+
+
+def pols_living(t):
+    """Number of policies: Living benefits"""
+    return 0
+
+
+def pols_maturity(t):
+    """Number of policies: Maturity"""
+    if t == pol.policy_term()[idx]:
+        return pols_if(t)
+    else:
+        return 0
+
+
+def pols_if_init(t):
+    """Number of policies: New business"""
+    return pol.policy_count()[idx] if t == 0 else 0
+
+
+def pols_other(t):
+    """Number of policies: Other benefits"""
+    return 0
+
+
+def pols_renewal(t):
+    """Number of policies: Renewal policies"""
+    return 0
+
+
+def pols_sick_hosp(t):
+    """Number of policies: Sickness Hospitalization"""
+    return 0
+
+
+def pols_surg(t):
+    """Number of policies: Surgery"""
+    return 0
+
+
+def pols_lapse(t):
+    """Number of policies: Surrender"""
+    return pols_if_beg1(t) * lapse_rate(t)
+
+
+def premiums(t):
+    """Premium income"""
+    return premium_pp(t) * pols_if_beg1(t)
+
+
+def profit_bef_tax(t):
+    """Profit before Tax"""
+
+    return (premiums(t)
+            + invst_income(t)
+            - claims(t)
+            - expenses(t)
+            - change_rsrv(t))
+
+
+def reserve_hosp_rsrv_end(t):
+    """Hospitalization reserve: End of period"""
+    return 0
+
+
+def reserve_prem_rsrv_end(t):
+    """Premium reserve: End of period"""
+    return reserve_prem_rsrv_end_pp(t) * pols_if(t)
+
+
+def reserve_total_end(t):
+    """Total reserve: End of period"""
+    return (reserve_prem_rsrv_end(t)
+            + reserve_uern_prem_end(t)
+            + reserve_hosp_rsrv_end(t))
+
+
+def reserve_uern_prem_end(t):
+    """Unearned Premium: End of period"""
+    return 0
+
+
+def ann_prem_pp(t):
+    """Annualized premium per policy at time ``t``"""
+    return sum_assured(t) * ann_prem_rate()
+
+
+def claims_acc_dth_pp(t):
+    """Accidental death benefit per policy"""
+    return 0
+
+
+def claims_acc_hosp_pp(t):
+    """Accidental hospitalization benefit per policy"""
+    return 0
+
+
+def claims_ann_pp(t):
+    """Annuity benefit per policy"""
+    return 0
+
+
+def claims_death_pp(t):
+    """Death benefit per policy"""
+    return sum_assured(t)
+
+
+def claims_living_pp(t):
+    """Living benefit per policy"""
+    return 0
+
+
+def claims_mat_pp(t):
+    """Maturity benefit per policy"""
+    return 0
+
+
+def claims_other_pp(t):
+    """Other benefit per policy"""
+    return 0
+
+
+def claims_sick_hosp_pp(t):
+    """Sickness hospitalization benefit per policy"""
+    return 0
+
+
+def claims_surg_pp(t):
+    """Surgery benefit per policy"""
+    return 0
+
+
+def claims_surr_pp(t):
+    """Surrender benefit per policy"""
+    return sum_assured(t) * (cash_value_rate(t)
+                                + cash_value_rate(t+1)) / 2
+
+
+def expense_acq_pp(t):
+    """Acquisition expense per policy at time t"""
+    if t == 0:
+        return (ann_prem_pp(t) * asmp.exps_acq_ann_prem()[idx]
+                + (sum_assured(t) * asmp.exps_acq_sa()[idx] + asmp.exps_acq_pol()[idx])
+                * inflation_factor(t) / inflation_factor(0))
+    else:
+        return 0
+
+
+def commissions_init_pp(t):
+    """Initial commission per policy at time t"""
+    if t == 0:
+        return premium_pp(t) * asmp.comm_init_prem()[idx] * (1 + asmp.cnsmp_tax())
+    else:
+        return 0
+
+
+def commissions_ren_pp(t):
+    """Renewal commission per policy at time t"""
+    if t == 0:
+        return 0
+    elif t < asmp.comm_ren_term()[idx]:
+        return premium_pp(t) * asmp.comm_ren_prem()[idx] * (1 + asmp.cnsmp_tax())
+    else:
+        return 0
+
+
+def expense_maint_pp(t):
+    """Maintenance expense per policy at time t"""
+    return (ann_prem_pp(t) * asmp.exps_maint_ann_prem()[idx]
+            + (sum_assured(t) * asmp.exps_maint_sa()[idx] + asmp.exps_maint_pol()[idx])
+            * inflation_factor(t))
+
+
+def exps_other_pp(t):
+    """Other expenses per policy at time t"""
+    return 0
+
+
+def invst_income_pp(t):
+    """Investment Income per policy from t to t+1"""
+    return (reserve_total_aft_mat_pp(t) + premium_pp(t)) * invst_ret_rate(t)
+
+
+def premium_pp(t):
+    """Premium income per policy from t to t+1"""
+    return sum_assured(t) * gross_prem_rate() * pol.prem_freq()[idx]
+
+
+def reserve_prem_rsrv_aft_mat_pp(t):
+    """Premium reserve per policy: After maturity"""
+    return sum_assured(t) * pol.ReserveNLP_Rate('VAL', t)
+
+
+def reserve_prem_rsrv_end_pp(t):
+    """Premium reserve per policy: End of period"""
+    return sum_assured(t) * pol.ReserveNLP_Rate('VAL', t)
+
+
+def reserve_total_aft_mat_pp(t):
+    """Total reserve per policy: After maturity"""
+    return (reserve_prem_rsrv_aft_mat_pp(t)
+           + reserve_uern_prem_aft_mat_pp(t))
+
+
+def reserve_uern_prem_aft_mat_pp(t):
+    """Unearned premium: After maturity"""
+    return 0 # sum_assured(t) * polset.UnernPremRate(polset, tt, True)
+
+
+def reserve_uern_prem_end_pp(t):
+    """Unearned reserve per policy: End of period"""
+    return 0 # sum_assured(t) * pol.UnernPremRate(polset, tt)
+
+
+def sum_assured(t):
+    """Sum assured per policy at time ``t``"""
+    return  pol.sum_assured()[idx]
+
+
+def proj_len():
+    """Projection length in years for the selected policy.
+
+    The projection ends at whichever comes first: the age at which
+    base mortality reaches 1 (returned by :func:`last_mort_age`),
+    or the end of the policy term.
+    """
+    return min(last_mort_age() - pol.issue_age()[idx],
+               pol.policy_term()[idx])
+
+
+def mort_rate(x):
+    """Base mortality rate at age ``x``"""
+
+    return asmp.mortality_tables()[x, asmp.mort_array_index()[idx]]
+
+
+def gross_prem_rate():
+    """Gross Premium Rate per Sum Assured per payment"""
+
+    alpha = pol.load_acq_sa()[idx]
+    beta = pol.load_maint_prem()[idx]
+    gamma = pol.load_maint_sa()[idx]
+    gamma2 = pol.load_maint_sa2()[idx]
+    delta = pol.load_maint_prem_waiver_prem()[idx]
+
+    x, n, m = pol.issue_age()[idx], pol.policy_term()[idx], pol.prem_term()[idx]
+
+    freq = pol.prem_freq()[idx]
+
+    comf = comm_table[
+        pol.sex()[idx],
+        pol.int_rate(RateBasisID.PREM)[idx],
+        pol.table_id(RateBasisID.PREM)[idx]]
+
+    if pol.product()[idx] == ProductID.TERM or pol.product()[idx] == ProductID.WL:
+        return (comf.Axn(x, n) + alpha + gamma * comf.AnnDuenx(x, n, freq)
+                + gamma2 * comf.AnnDuenx(x, n-m, 1, m)) / (1-beta-delta) / freq / comf.AnnDuenx(x, m, freq)
+
+    elif pol.product()[idx] == ProductID.ENDW:
+        return (comf.Exn(x, n) + comf.Axn(x, n) + alpha + gamma * comf.AnnDuenx(x, n, freq)
+                + gamma2 * comf.AnnDuenx(x, n-m, 1, m)) / (1-beta-delta) / freq / comf.AnnDuenx(x, m, freq)
+    else:
+        raise ValueError('invalid product')
+
+
+def mort_factor(y):
+    """Mortality factor"""
+    return asmp.asmp_tables()[min(y, asmp.asmp_table_len() - 1), asmp.mort_factor_index()[idx]]
+
+
+def lapse_rate(y):
+    """Surrender Rate"""
+    return asmp.asmp_tables()[min(y, asmp.asmp_table_len() - 1), asmp.lapse_rate_index()[idx]]
+
+
+def ann_prem_rate():
+    """Annualized Premium Rate per Sum Assured"""
+    return gross_prem_rate() * (1/10 if pol.prem_freq()[idx] == 0 else pol.prem_freq()[idx])
+
+
+def cash_value_rate(t):
+    """Cash Value Rate per Sum Assured"""
+    return max(reserve_nlp_rate(RateBasisID.PREM, t) - surr_charge(t), 0)
+
+
+def net_prem_rate(basis):
+    """Net Premium Rate"""
+
+    gamma2 = pol.load_maint_sa2()[idx]
+
+    comf = comm_table[
+        pol.sex()[idx],
+        pol.int_rate(basis)[idx],
+        pol.table_id(basis)[idx]]
+
+    x, n, m = pol.issue_age()[idx], pol.policy_term()[idx], pol.prem_term()[idx]
+
+    if pol.product()[idx] == ProductID.TERM or pol.product()[idx] == ProductID.WL:
+        return (comf.Axn(x, n) + gamma2 * comf.AnnDuenx(x, n-m, 1, m)) / comf.AnnDuenx(x, n)
+
+    elif pol.product()[idx] == ProductID.ENDW:
+        return (comf.Axn(x, n) + gamma2 * comf.AnnDuenx(x, n-m, 1, m)) / comf.AnnDuenx(x, n)
+
+    else:
+        raise ValueError('invalid product')
+
+
+def reserve_nlp_rate(basis, t):
+    """Net level premium reserve rate"""
+
+    gamma2 = pol.load_maint_sa2()[idx]
+
+    comf = comm_table[
+        pol.sex()[idx],
+        pol.int_rate(basis)[idx],
+        pol.table_id(basis)[idx]]
+
+    x, n, m = pol.issue_age()[idx], pol.policy_term()[idx], pol.prem_term()[idx]
+
+    if t <= m:
+        return comf.Axn(x+t, n-t) + gamma2 * comf.AnnDuenx(x+t, n-m, 1, m-t) \
+                - net_prem_rate(basis) * comf.AnnDuenx(x+t, m-t)
+    else:
+        return comf.Axn(x+t, n-t) + gamma2 * comf.AnnDuenx(x+t, n-m, 1, m-t)
+
+
+def surr_charge(t):
+    """Surrender Charge Rate per Sum Assured"""
+    m = pol.prem_term()[idx]
+    return pol.init_surr_charge()[idx] * max((min(m, 10) - t) / min(m, 10), 0)
+
+
+def last_mort_age():
+    """Age at which the base mortality rate reaches 1 for this policy.
+
+    Refers to
+    :func:`~annuallife.TradLife_A.Assumptions.last_mort_age` for the
+    selected policy.
+    """
+    return asmp.last_mort_age()[idx]
+
+
+def inflation_factor(t):
+    """Inflation factor at time ``t`` used to adjust expense cashflows.
+
+    Compounded from :func:`~annuallife.TradLife_A.Assumptions.inflation_rate`
+    starting from ``inflation_factor(0) = 1``.
+    """
+    if t == 0:
+        return 1
+    else:
+        return inflation_factor(t-1) / (1 + asmp.inflation_rate())
+
+
+def disc_rate_mth(t):
+    """Discount rate at time ``t``.
+
+    Refers to
+    :func:`Economic[scen_id].disc_rate_mth<annuallife.TradLife_A.Economic.disc_rate_mth>`.
+    """
+    return scen.disc_rate_mth(t)
+
+
+# ---------------------------------------------------------------------------
+# References
+
+scen = ("Interface", ("..", "Economic"), "auto")
+
+asmp = ("Interface", ("..", "Assumptions"), "auto")
+
+pol = ("Interface", ("..", "PolicyAttrs"), "auto")
+
+comm_table = ("Interface", ("..", "CommTable"), "auto")

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/CommTable/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/CommTable/__init__.py
@@ -1,0 +1,286 @@
+"""Commutation functions and actuarial notations.
+
+The :mod:`~annuallife.TradLife_A.CommTable` Space provides commutation
+functions and actuarial notations, such as :math:`D_{x}` and
+:math:`\\require{enclose}{}_{f|}\\overline{A}_{x}`.
+Mortality tables are read from the ``MortalityTables`` range in
+*input.xlsx* through
+:func:`~annuallife.TradLife_A.InputData.mortality_tables` and indexed
+through :func:`mortality_rates`.
+
+Parameters and References
+-------------------------
+
+This Space is parameterized with :attr:`Sex`, :attr:`IntRate` and
+:attr:`TableID`::
+
+        >>> m.CommTable.parameters
+        ('Sex', 'IntRate', 'Table')
+
+Each ItemSpace represents commutation functions and actuarial notations
+for a combination of :attr:`Sex`, :attr:`IntRate` and :attr:`TableID`.
+For example, ``CommTable[SexID.M, 0.03, 1]`` contains commutation
+functions and actuarial notations for Male, an interest rate of 3% and
+mortality table 1.
+
+Attributes:
+    Sex: A :mod:`~annuallife.TradLife_A.Enums.SexID` code identifying
+        the column in the mortality table.
+    IntRate(:obj:`float`): The constant interest rate for discounting.
+    Table: Identifier of the mortality table within
+        :func:`~annuallife.TradLife_A.InputData.mortality_tables`.
+
+.. rubric:: References
+
+Attributes:
+    mortality_tables: Alias for
+        :func:`~annuallife.TradLife_A.InputData.mortality_tables`.
+
+Example:
+
+    An example of :mod:`~annuallife.TradLife_A.CommTable`::
+
+        >>> m.CommTable[SexID.M, 0.03, 1].AnnDuenx(40, 10)
+        8.725179890621531
+
+External Links:
+    * `International actuarial notation by F.S.Perryman <https://www.casact.org/pubs/proceed/proceed49/49123.pdf>`_
+    * `Actuarial notations on Wikipedia <https://en.wikipedia.org/wiki/Actuarial_notation>`_
+
+
+Cells Summary
+-------------
+
+Life Table
+^^^^^^^^^^
+
+The underlying life-table columns — survivors, deaths, mortality
+probability and the per-age mortality rates selected for this Space's
+sex and table.
+
+.. autosummary::
+
+   ~lx
+   ~dx
+   ~qx
+   ~mortality_rates
+
+
+Commutation Columns
+^^^^^^^^^^^^^^^^^^^
+
+The discount factor and the commutation columns :math:`D_x`,
+:math:`C_x`, :math:`M_x` and :math:`N_x` built from the life table.
+
+.. autosummary::
+
+   ~disc
+   ~Dx
+   ~Cx
+   ~Mx
+   ~Nx
+
+
+Assurances and Endowments
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Present values of whole-life and term assurances and of pure
+endowments.
+
+.. autosummary::
+
+   ~Ax
+   ~Axn
+   ~Exn
+
+
+Annuities
+^^^^^^^^^
+
+Present values of temporary and lifetime annuities-due, with optional
+split payments and deferment.
+
+.. autosummary::
+
+   ~AnnDuenx
+   ~AnnDuex
+
+"""
+
+from modelx.serialize.jsonvalues import *
+
+_formula = lambda Sex, IntRate, Table: None
+
+_bases = []
+
+_allow_none = None
+
+_spaces = []
+
+# ---------------------------------------------------------------------------
+# Cells
+
+def AnnDuenx(x, n, k=1, f=0):
+    """ The present value of an annuity-due.
+
+    .. math::
+
+        \\require{enclose}{}_{f|}\\ddot{a}_{x:\\enclose{actuarial}{n}}^{(k)}
+
+
+    Args:
+        x(int): age
+        n(int): length of annuity payments in years
+        k(int, optional): number of split payments in a year
+        f(int, optional): waiting period in years
+
+    """
+    if Dx(x) == 0:
+        return 0
+
+    result = (Nx(x+f) - Nx(x+f+n)) / Dx(x)
+
+    if k > 1:
+        return result - (k-1) / (2*k) * (1 - Dx(x+f+n) / Dx(x))
+    else:
+        return result
+
+
+def AnnDuex(x, k, f=0):
+    """The present value of a lifetime annuity due.
+
+    Args:
+        x(int): age
+        k(int, optional): number of split payments in a year
+        f(int, optional): waiting period in years
+    """
+    if Dx(x) == 0:
+        return 0
+
+    result = (Nx(x+f)) / Dx(x)
+
+    if k > 1:
+        return result - (k-1) / (2*k)
+    else:
+        return result
+
+
+def Ax(x, f=0):
+    """The present value of a lifetime assurance on a person at age ``x``
+    payable immediately upon death, optionally with an waiting period of ``f`` years.
+
+    .. math::
+
+        \\require{enclose}{}_{f|}\\overline{A}_{x}
+    """
+    if Dx(x) == 0:
+        return 0
+    else:
+        return Mx(x+f) / Dx(x)
+
+
+def Axn(x, n, f=0):
+    """The present value of an assurance on a person at age ``x`` payable
+    immediately upon death, optionally with an waiting period of ``f`` years.
+
+    .. math::
+
+        \\require{enclose}{}_{f|}\\overline{A}^{1}_{x:\\enclose{actuarial}{n}}
+
+    """
+    if Dx(x) == 0:
+        return 0
+    else:
+        return (Mx(x+f) - Mx(x+f+n)) / Dx(x)
+
+
+def Cx(x):
+    """The commutation column :math:`\\overline{C_x}`.
+    """
+
+    return dx(x) * disc()**(x+1/2)
+
+
+def Dx(x):
+    """The commutation column :math:`D_{x} = l_{x}v^{x}`.
+    """
+    return lx(x) * disc() ** x
+
+
+def Exn(x, n):
+    """ The value of an endowment on a person at age ``x``
+    payable after n years
+
+    .. math::
+
+        {}_{n}E_x
+
+    """
+    if Dx(x) == 0:
+        return 0
+    else:
+        return Dx(x+n) / Dx(x)
+
+
+def Mx(x):
+    """The commutation column :math:`M_x`."""
+
+    if x >= 110:
+        return Dx(x)
+    else:
+        return Mx(x+1) + Cx(x)
+
+
+def Nx(x):
+    """The commutation column :math:`N_x`."""
+    if x >= 110:    # TODO: Get the last age from the table
+        return Dx(x)
+    else:
+        return Nx(x+1) + Dx(x)
+
+
+def disc():
+    """The discount factor :math:`v = 1/(1 + i)`."""
+    return 1 / (1 + IntRate)
+
+
+def dx(x):
+    """The number of persons who die between ages ``x`` and ``x+1``"""
+    return lx(x) * qx(x)
+
+
+def lx(x):
+    """The number of persons remaining at age ``x``. """
+    if x == 0:
+        return 100000
+    else:
+        return lx(x-1) - dx(x-1)
+
+
+def qx(x):
+    """Probability that a person at age ``x`` will die in one year."""
+    return mortality_rates()[x]
+
+
+def mortality_rates():
+    """Mortality rates for the selected ``Sex`` and ``Table``.
+
+    Selects the column of :func:`~annuallife.TradLife_A.InputData.mortality_tables`
+    matching this Space's :attr:`Table` and :attr:`Sex` parameters and
+    returns the resulting per-age mortality rate Series.
+    """
+    pos = list((t, getattr(SexID, s)) for t, s in mortality_tables().columns).index((Table, Sex))
+
+    return mortality_tables().iloc[:, pos]
+
+
+# ---------------------------------------------------------------------------
+# References
+
+Sex = "M"
+
+IntRate = 0.01
+
+TableID = 1
+
+mortality_tables = ("Interface", ("..", "InputData", "mortality_tables"), "absolute")

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/Economic/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/Economic/__init__.py
@@ -1,0 +1,88 @@
+"""Scenario economic rates for a single traditional life projection.
+
+The ``Economic`` Space provides the per-scenario interest rates used
+to discount cashflows and to credit investment return, read from
+*input.xlsx*.
+
+Parameters and References
+-------------------------
+
+``Economic`` is parameterized with :attr:`scen_id`::
+
+        >>> m.Economic.parameters
+        ('scen_id',)
+
+Each ItemSpace represents economic scenarios for a specific
+:attr:`scen_id`. For example, ``Economic[1]`` contains economic
+scenarios for ``scen_id`` 1.
+
+Attributes:
+    scen_id(:obj:`int`): Scenario ID.
+
+.. rubric:: References
+
+Attributes:
+    input_data: Alias for :mod:`~annuallife.TradLife_A.InputData`.
+        Scenario interest rates are read from the ``Scenarios`` range
+        in *input.xlsx* through
+        :func:`~annuallife.TradLife_A.InputData.scenarios`.
+
+Example:
+
+    An example of ``Economic`` in :mod:`~annuallife.TradLife_A`::
+
+        >>> m.Economic[1].disc_rate_mth(0)
+        0.015
+
+
+Cells Summary
+-------------
+
+The discount rate and the investment return rate for the selected
+scenario at time ``t``.
+
+.. autosummary::
+
+   ~disc_rate_mth
+   ~invst_ret_rate
+
+"""
+
+from modelx.serialize.jsonvalues import *
+
+_formula = lambda scen_id: None
+
+_bases = []
+
+_allow_none = None
+
+_spaces = []
+
+# ---------------------------------------------------------------------------
+# Cells
+
+def disc_rate_mth(t):
+    """Discount rate at time ``t``.
+
+    Read from the ``Scenarios`` range in *input.xlsx* (column
+    ``IntRate``) through
+    :func:`~annuallife.TradLife_A.InputData.scenarios`,
+    keyed by the current :attr:`scen_id` and ``t``.
+    """
+    return input_data.scenarios()['IntRate'].at[(scen_id, t)]
+
+
+def invst_ret_rate(t):
+    """Rate of investment return at time ``t``.
+
+    Set equal to :func:`disc_rate_mth`.
+    """
+    return disc_rate_mth(t)
+
+
+# ---------------------------------------------------------------------------
+# References
+
+scen_id = 1
+
+input_data = ("Interface", ("..", "InputData"), "auto")

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/Enums/ProductID/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/Enums/ProductID/__init__.py
@@ -1,0 +1,33 @@
+"""Product type codes.
+
+Integer codes identifying the product of a policy. Used by
+:func:`~annuallife.TradLife_A.PolicyAttrs.product` and by the
+product-dependent branches in
+:func:`~annuallife.TradLife_A.BaseProj.gross_prem_rate` and
+:func:`~annuallife.TradLife_A.BaseProj.net_prem_rate`.
+
+Members:
+    TERM(:obj:`int`): Term insurance.
+    WL(:obj:`int`): Whole life insurance.
+    ENDW(:obj:`int`): Endowment insurance.
+
+"""
+
+from modelx.serialize.jsonvalues import *
+
+_formula = None
+
+_bases = []
+
+_allow_none = None
+
+_spaces = []
+
+# ---------------------------------------------------------------------------
+# References
+
+TERM = 1
+
+WL = 2
+
+ENDW = 3

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/Enums/RateBasisID/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/Enums/RateBasisID/__init__.py
@@ -1,0 +1,33 @@
+"""Rate basis codes.
+
+Integer codes used to select between the premium and valuation
+interest-rate / mortality-table bases. Consumed by
+:func:`~annuallife.TradLife_A.PolicyAttrs.int_rate` and
+:func:`~annuallife.TradLife_A.PolicyAttrs.table_id` and by the
+commutation-table lookups in
+:func:`~annuallife.TradLife_A.BaseProj.gross_prem_rate`,
+:func:`~annuallife.TradLife_A.BaseProj.net_prem_rate` and
+:func:`~annuallife.TradLife_A.BaseProj.reserve_nlp_rate`.
+
+Members:
+    PREM(:obj:`int`): Premium basis.
+    VAL(:obj:`int`): Valuation basis.
+
+"""
+
+from modelx.serialize.jsonvalues import *
+
+_formula = None
+
+_bases = []
+
+_allow_none = None
+
+_spaces = []
+
+# ---------------------------------------------------------------------------
+# References
+
+PREM = 1
+
+VAL = 2

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/Enums/SexID/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/Enums/SexID/__init__.py
@@ -1,0 +1,30 @@
+"""Sex codes.
+
+Integer codes used to identify the sex column of a mortality table.
+Returned per policy by :func:`~annuallife.TradLife_A.PolicyAttrs.sex`
+and consumed by the indexing logic in
+:func:`~annuallife.TradLife_A.Assumptions.mort_array_index` and
+:func:`~annuallife.TradLife_A.CommTable.mortality_rates`.
+
+Members:
+    M(:obj:`int`): Male.
+    F(:obj:`int`): Female.
+
+"""
+
+from modelx.serialize.jsonvalues import *
+
+_formula = None
+
+_bases = []
+
+_allow_none = None
+
+_spaces = []
+
+# ---------------------------------------------------------------------------
+# References
+
+M = 1
+
+F = 2

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/Enums/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/Enums/__init__.py
@@ -1,0 +1,32 @@
+"""Enum-style codes used across :mod:`~annuallife.TradLife_A`.
+
+This Space groups the small integer-coded enumerations referenced by
+the projection cells. Each enum is exposed as a child Space whose
+References hold the integer codes for its members:
+
+* :mod:`~annuallife.TradLife_A.Enums.ProductID` - product type codes
+  (``TERM``, ``WL``, ``ENDW``).
+* :mod:`~annuallife.TradLife_A.Enums.SexID` - sex codes used to index
+  mortality tables (``M``, ``F``).
+* :mod:`~annuallife.TradLife_A.Enums.RateBasisID` - rate-basis codes
+  used by the commutation lookup (``PREM``, ``VAL``).
+
+The three child spaces are also re-exported at the model level as
+``ProductID``, ``SexID`` and ``RateBasisID`` for convenience.
+
+"""
+
+from modelx.serialize.jsonvalues import *
+
+_formula = None
+
+_bases = []
+
+_allow_none = None
+
+_spaces = [
+    "ProductID",
+    "SexID",
+    "RateBasisID"
+]
+

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/InputData/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/InputData/__init__.py
@@ -1,0 +1,331 @@
+"""Input data loaded from *input.xlsx*.
+
+The :mod:`~annuallife.TradLife_A.InputData` Space contains Cells that
+load values from named ranges in the Excel input file, *input.xlsx*,
+and helper Cells that turn those ranges into pandas objects ready for
+the rest of the model.
+
+Per-policy attributes, assumption tables, scenarios, mortality tables
+and product specs are loaded on demand by the cells listed below. The
+workbook itself is opened lazily by :func:`input_workbook`.
+
+The table below lists the cells and the Excel named ranges they read.
+
+============================== =====================  ==========================================
+ Cell                           Named range            Purpose
+============================== =====================  ==========================================
+:func:`policy_data`            ``PolicyData``         Per-policy attributes for model points.
+:func:`product_spec`           ``ProductSpecTable``   Per-product loading and rate tables.
+:func:`assumption`             ``AssumptionTable``    Lookup table of assumption keys.
+:func:`assumption_tables`      ``AsmpByDuration``     Duration-based mortality / lapse tables.
+:func:`mortality_tables`       ``MortalityTables``    Mortality tables keyed by Sex / Table.
+:func:`scenarios`              ``Scenarios``          Scenario interest-rate paths.
+:func:`discount_rate`          ``LargePolDiscount``   Premium discount by sum-assured band.
+:func:`prem_waiver_cost`       ``PremiumWaiverCost``  Premium-waiver cost lookup.
+:func:`const_params`           ``ConstParams``        Scalar parameters used across the model.
+============================== =====================  ==========================================
+
+Parameters and References
+-------------------------
+
+Attributes:
+    input_file_name(:obj:`str`): Name of the Excel workbook to read.
+        Defaults to ``"input.xlsx"`` and is resolved relative to the
+        parent directory of the model.
+    openpyxl: The :mod:`openpyxl` module used to open the workbook.
+
+
+Cells Summary
+-------------
+
+Workbook
+^^^^^^^^
+
+Opens the Excel input workbook lazily; every other cell reads from it.
+
+.. autosummary::
+
+   ~input_workbook
+
+
+Input Tables
+^^^^^^^^^^^^
+
+Named ranges loaded as pandas objects: policy data, mortality and
+assumption tables, scenarios, discount and premium-waiver lookups and
+the scalar constants.
+
+.. autosummary::
+
+   ~policy_data
+   ~mortality_tables
+   ~mort_table_last_ages
+   ~assumption_tables
+   ~scenarios
+   ~discount_rate
+   ~prem_waiver_cost
+   ~const_params
+
+
+Lookups
+^^^^^^^
+
+Column lookups into the assumption and product-specification tables,
+keyed by the model point lookup levels.
+
+.. autosummary::
+
+   ~assumption
+   ~product_spec
+
+
+Helpers
+^^^^^^^
+
+Generic readers that turn a named range into a ``DataFrame``, a
+``dict`` or a keyed ``Series``.
+
+.. autosummary::
+
+   ~get_named_range_as_df
+   ~get_named_range_as_dict
+   ~get_param_series
+
+"""
+
+from modelx.serialize.jsonvalues import *
+
+_formula = None
+
+_bases = []
+
+_allow_none = True
+
+_spaces = []
+
+# ---------------------------------------------------------------------------
+# Cells
+
+def input_workbook():
+    """Open and return the input Excel workbook.
+
+    Loads the workbook named :attr:`input_file_name` from the parent
+    directory of the model with ``data_only=True``, so that formula
+    cells return their last cached values.
+    """
+    return openpyxl.load_workbook(
+        _model.path.parent / input_file_name,
+        data_only=True)
+
+
+def policy_data():
+    """Policy data table.
+
+    Returns the ``PolicyData`` named range as a ``DataFrame``, indexed by
+    the first column (the policy ID).
+    """
+    return get_named_range_as_df('PolicyData', index_len=1)
+
+
+def mortality_tables():
+    """Mortality tables.
+
+    Reads the ``MortalityTables`` named range, which has a two-row
+    header of ``(MortTable, Sex)`` and an age column, and returns a
+    ``DataFrame`` indexed by age with a ``MultiIndex`` over the columns.
+    """
+    wb = input_workbook()
+
+    sheet_name, cell_range = next(wb.defined_names["MortalityTables"].destinations)
+    ws = wb[sheet_name]
+
+    rows = list(ws[cell_range.replace('$', '')])
+
+    # Extract the two header rows
+    top_header = [cell.value for cell in rows[0]]
+    sub_header = [cell.value for cell in rows[1]]
+
+    # Forward-fill None values in the top header (from merged cells)
+    filled_top = []
+    last = None
+    for v in top_header:
+        if v is not None:
+            last = v
+        filled_top.append(last)
+
+    # Skip the first entry of each header row (those are the index's "name" cells)
+    columns = pd.MultiIndex.from_arrays([filled_top[1:], sub_header[1:]],
+                                        names=[filled_top[0], sub_header[0]])
+
+    # Data: first column becomes index, rest becomes the DataFrame body
+    # Convert None to np.nan in cell values
+    raw = [[np.nan if cell.value is None else cell.value for cell in row] for row in rows[2:]]
+
+    index = [row[0] for row in raw]
+    data = [row[1:] for row in raw]
+
+    df = pd.DataFrame(data, columns=columns, index=index)
+
+    return df
+
+
+def mort_table_last_ages():
+    """First Age (the row index) at which mortality reaches 1, per column.
+
+    Returns a Series indexed by ``mortality_tables().columns``
+    (a MultiIndex of (MortTable, Sex)) with the Age value from the row index.
+    """
+    df = mortality_tables()
+    return (df == 1).idxmax()
+
+
+def assumption_tables():
+    """Assumption tables by duration.
+
+    Returns the ``AsmpByDuration`` named range as a ``DataFrame``,
+    indexed by the first column (typically duration).
+    """
+    return get_named_range_as_df('AsmpByDuration', index_len=1)
+
+
+def get_named_range_as_df(name, index_len=0):
+    """Read an Excel named range as a ``DataFrame``.
+
+    Args:
+        name(:obj:`str`): The Excel defined-name to read.
+        index_len(:obj:`int`, optional): Number of leading columns to
+            use as the DataFrame index. Defaults to 0 (no index column).
+    """
+    wb = input_workbook()
+
+    sheet_name, cell_range = next(wb.defined_names[name].destinations)
+    ws = wb[sheet_name]
+
+    rows = list(ws[cell_range.replace('$', '')])
+    headers = [cell.value for cell in rows[0]]
+    data = [[cell.value if cell.value is not None else np.nan for cell in row] 
+            for row in rows[1:]]
+
+    df = pd.DataFrame(data, columns=headers)
+
+    if index_len > 0:
+        return df.set_index(headers[:index_len])
+    else:
+        return df
+
+
+_is_cached = False
+
+def scenarios():
+    """Economic scenarios.
+
+    Returns the ``Scenarios`` named range as a ``DataFrame``, indexed by
+    the first two columns (scenario ID and time).
+    """
+    return get_named_range_as_df('Scenarios', index_len=2)
+
+
+def get_named_range_as_dict(name):
+    """Read a two-column Excel named range as a :obj:`dict`.
+
+    The first column of the range becomes the dict keys and the second
+    column becomes the values.
+    """
+    wb = input_workbook()
+
+    sheet_name, cell_range = next(wb.defined_names[name].destinations)
+    ws = wb[sheet_name]
+
+    rows = list(ws[cell_range.replace('$', '')])
+
+    return {row[0].value: row[1].value for row in rows}
+
+
+_is_cached = False
+
+def discount_rate():
+    """Per-policy premium discount based on sum-assured bands.
+
+    Reads the ``LargePolDiscount`` named range, builds the breakpoints
+    of the sum-assured bands and returns a ``Series`` aligned with
+    :func:`policy_data` giving the discount that applies to each policy.
+    """
+    table = get_named_range_as_dict('LargePolDiscount')
+
+    bins = [-np.inf] + list(table.keys())[:-1] + [np.inf]
+    vals = list(table.values())
+
+    return pd.cut(
+         policy_data()['SumAssured'],
+         bins=bins,
+         labels=vals,
+         right=False,        # left-closed: [x, y)
+     ).astype(float)
+
+
+def prem_waiver_cost():
+    """Premium-waiver cost lookup as a :obj:`dict`.
+
+    Returns the ``PremiumWaiverCost`` named range, mapping the upper
+    bound of a policy-term band to its premium-waiver loading.
+    """
+    return get_named_range_as_dict('PremiumWaiverCost')
+
+
+def assumption(name):
+    """Lookup column ``name`` of the ``AssumptionTable`` range.
+
+    Returns a ``Series`` keyed by the lookup levels (such as
+    ``Product``, ``PolType``, ``Gen``) that are not entirely empty
+    for column ``name``.
+    """
+    return get_param_series('AssumptionTable', name)
+
+
+def product_spec(name):
+    """Lookup column ``name`` of the ``ProductSpecTable`` range.
+
+    Returns a ``Series`` keyed by the lookup levels (such as
+    ``Product``, ``PolType``, ``Gen``) that are not entirely empty
+    for column ``name``.
+    """
+    return get_param_series('ProductSpecTable', name)
+
+
+def get_param_series(range_name, col_name):
+    """Helper that reads column ``col_name`` from ``range_name`` as a ``Series``.
+
+    The named range is loaded via :func:`get_named_range_as_df` with the
+    first three columns used as a `MultiIndex`. Any index level that is
+    entirely empty for ``col_name`` is dropped, and a partially empty
+    level raises :class:`ValueError`.
+    """
+    df = get_named_range_as_df(range_name, index_len=3)[col_name].dropna()
+
+    levels_to_drop = []
+
+    for key in df.index.names:
+        if df.index.get_level_values(key).isna().all():
+            levels_to_drop.append(key)
+        elif df.index.get_level_values(key).isna().any():
+            raise ValueError(f"'{key}' contains missing values for {col_name}")
+
+    if levels_to_drop:
+        df = df.droplevel(levels_to_drop)
+
+    return df
+
+
+_is_cached = False
+
+def const_params():
+    """Scalar parameters from the ``ConstParams`` named range as a :obj:`dict`."""
+    return get_named_range_as_dict('ConstParams')
+
+
+# ---------------------------------------------------------------------------
+# References
+
+input_file_name = "input.xlsx"
+
+openpyxl = ("Module", "openpyxl")

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/PV/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/PV/__init__.py
@@ -1,0 +1,216 @@
+"""Present values of the projected cashflows for a single traditional life policy.
+
+This Space defines the Cells that discount the cashflows projected in
+:mod:`~annuallife.TradLife_A.BaseProj` back to time 0. It is one of the
+base Spaces inherited by :mod:`~annuallife.TradLife_A.Projection`.
+
+Each present-value cell is defined recursively in ``t``: the recursion
+terminates at ``t > proj_len()`` by returning ``0``, where
+:func:`~annuallife.TradLife_A.BaseProj.proj_len` is the projection
+length for the selected policy. Discounting uses the
+:func:`~annuallife.TradLife_A.BaseProj.disc_rate_mth` cell that resolves
+to :func:`~annuallife.TradLife_A.Economic.disc_rate_mth` for the
+selected scenario.
+
+
+Cells Summary
+-------------
+
+Premiums and Claims
+^^^^^^^^^^^^^^^^^^^
+
+Present value of premium income and of the claim cashflows by cause.
+
+.. autosummary::
+
+   ~pv_premiums
+   ~pv_claims_death
+   ~pv_claims_mat
+   ~pv_claims_surr
+   ~pv_claims
+
+
+Expenses and Commissions
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Present value of acquisition, maintenance and total expenses and of
+commissions.
+
+.. autosummary::
+
+   ~pv_exps_acq
+   ~pv_commissions
+   ~pv_exps_maint
+   ~pv_expenses
+
+
+Net Cashflow
+^^^^^^^^^^^^
+
+Present value of the net liability cashflow and the interest accreted
+on it.
+
+.. autosummary::
+
+   ~pv_net_cf
+   ~interest_net_cf
+
+
+Validation
+^^^^^^^^^^
+
+An alternative recursive net-cashflow present value and the check
+that it agrees with :func:`pv_net_cf`.
+
+.. autosummary::
+
+   ~pv_net_cf_for_check
+   ~pv_check
+
+
+Exposure
+^^^^^^^^
+
+Present value of the insurance in force.
+
+.. autosummary::
+
+   ~pv_sum_insur_if
+
+"""
+
+from modelx.serialize.jsonvalues import *
+
+_formula = None
+
+_bases = []
+
+_allow_none = None
+
+_spaces = []
+
+# ---------------------------------------------------------------------------
+# Cells
+
+def interest_net_cf(t):
+    """Interest accreted on pv of net cashflows"""
+    if t > proj_len():
+        return 0
+    else:
+        return (pv_net_cf(t)
+                - premiums(t)
+                + expenses(t)) * disc_rate_mth(t)
+
+
+def pv_claims_death(t):
+    """Present value of death benefits"""
+    if t > proj_len():
+        return 0
+    else:
+        return (-claims_death(t) + pv_claims_death(t+1)) / (1 + disc_rate_mth(t))
+
+
+def pv_claims_mat(t):
+    """Present value of maturity benefits"""
+    if t > proj_len():
+        return 0
+    else:
+        return (-claims_mat(t) + pv_claims_mat(t+1)) / (1 + disc_rate_mth(t))
+
+
+def pv_claims_surr(t):
+    """Present value of surrender benefits"""
+    if t > proj_len():
+        return 0
+    else:
+        return (-claims_surr(t) + pv_claims_surr(t+1)) / (1 + disc_rate_mth(t))
+
+
+def pv_claims(t):
+    """Present value of total benefits"""
+    if t > proj_len():
+        return 0
+    else:
+        return (-claims(t) + pv_claims(t+1)) / (1 + disc_rate_mth(t))
+
+
+def pv_check(t):
+    """Difference between :func:`pv_net_cf` and :func:`pv_net_cf_for_check`.
+
+    Used as a numerical sanity check; should be zero (within floating
+    point error) at every ``t``.
+    """
+    return pv_net_cf(t) - pv_net_cf_for_check(t)
+
+
+def pv_exps_acq(t):
+    """Present value of acquisition expenses"""
+    if t > proj_len():
+        return 0
+    else:
+        return - exps_acq(t) + pv_exps_acq(t+1) / (1 + disc_rate_mth(t))
+
+
+def pv_commissions(t):
+    """Present value of commission expenses"""
+    if t > proj_len():
+        return 0
+    else:
+        return - commissions(t) + pv_commissions(t+1) / (1 + disc_rate_mth(t))
+
+
+def pv_exps_maint(t):
+    """Present value of maintenance expenses"""
+    if t > proj_len():
+        return 0
+    else:
+        return - exps_maint(t) + pv_exps_maint(t+1) / (1 + disc_rate_mth(t))
+
+
+def pv_expenses(t):
+    """Present value of total expenses"""
+    if t > proj_len():
+        return 0
+    else:
+        return - expenses(t) + pv_expenses(t+1) / (1 + disc_rate_mth(t))
+
+
+def pv_net_cf(t):
+    """Present value of net cashflow"""
+    return (pv_premiums(t)
+            + pv_expenses(t)
+            + pv_claims(t))
+
+
+def pv_net_cf_for_check(t):
+    """Present value of net cashflow computed recursively for validation.
+
+    An alternative recursive definition of :func:`pv_net_cf` used by
+    :func:`pv_check` to verify that the closed-form sum and the
+    recursion agree.
+    """
+    if t > proj_len():
+        return 0
+    else:
+        return (premiums(t)
+                - expenses(t)
+                - claims(t) / (1 + disc_rate_mth(t))
+                + pv_net_cf(t+1) / (1 + disc_rate_mth(t)))
+
+
+def pv_premiums(t):
+    """Present value of premium income"""
+    if t > proj_len():
+        return 0
+    else:
+        return premiums(t) + pv_premiums(t+1) / (1 + disc_rate_mth(t))
+
+
+def pv_sum_insur_if(t):
+    """Present value of insurance in-force"""
+    if t > proj_len():
+        return 0
+    else:
+        return insur_if_beg1(t) + pv_sum_insur_if(t+1) / (1 + disc_rate_mth(t))
+
+

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/PolicyAttrs/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/PolicyAttrs/__init__.py
@@ -1,0 +1,336 @@
+"""Policy attributes and policy values.
+
+This Space holds policy attributes and policy-level values used by
+:mod:`~annuallife.TradLife_A.Projection` and its base spaces.
+
+Some Cells in this Space, such as :func:`product` and :func:`issue_age`,
+retrieve attributes for the model points from
+:func:`~annuallife.TradLife_A.InputData.policy_data`. Other Cells,
+such as those used by
+:func:`~annuallife.TradLife_A.BaseProj.gross_prem_rate`, derive
+policy-level values from product specs looked up through
+:func:`~annuallife.TradLife_A.InputData.product_spec`.
+
+Most cells return per-policy NumPy arrays whose layout matches the rows
+of :func:`~annuallife.TradLife_A.InputData.policy_data`, so callers
+index into them with the integer policy index ``idx``.
+
+Parameters and References
+-------------------------
+
+Attributes:
+    input_data: Alias for :mod:`~annuallife.TradLife_A.InputData`.
+        Per-policy attributes are read from the ``PolicyData`` range
+        in *input.xlsx* via
+        :func:`~annuallife.TradLife_A.InputData.policy_data`,
+        and product specs from
+        :func:`~annuallife.TradLife_A.InputData.product_spec`.
+    prem_term: Alias for :func:`policy_term`.
+    return_array(:obj:`bool`): When ``True`` (the default), helper
+        functions inherited from
+        :mod:`~annuallife.TradLife_A.Utilities` return NumPy arrays
+        instead of pandas objects.
+
+.. rubric:: Inherited helpers
+
+Inherited from :mod:`~annuallife.TradLife_A.Utilities`:
+
+* :func:`~annuallife.TradLife_A.Utilities.pandas_to_array`
+* :func:`~annuallife.TradLife_A.Utilities.map_to_policies`
+
+
+Cells Summary
+-------------
+
+Policy Attributes
+^^^^^^^^^^^^^^^^^
+
+Model point attributes read directly from
+:func:`~annuallife.TradLife_A.InputData.policy_data` for each policy.
+
+.. autosummary::
+
+   ~product
+   ~policy_type
+   ~sex
+   ~issue_age
+   ~prem_freq
+   ~policy_term
+   ~policy_count
+   ~sum_assured
+   ~gen
+   ~channel
+   ~duration
+
+
+Product Bases
+^^^^^^^^^^^^^
+
+Per-policy interest rate and mortality table identifiers, selected by
+rate basis (premium or valuation).
+
+.. autosummary::
+
+   ~int_rate
+   ~table_id
+
+
+Loadings
+^^^^^^^^
+
+Per-policy acquisition and maintenance loadings used by
+:func:`~annuallife.TradLife_A.BaseProj.gross_prem_rate`, together with
+the raw ``ProductSpecTable`` parameters they are built from.
+
+.. autosummary::
+
+   ~load_acq_sa
+   ~load_acq_sa_param1
+   ~load_acq_sa_param2
+   ~load_maint_prem
+   ~load_maint_prem_param1
+   ~load_maint_prem_param2
+   ~load_maint_prem_waiver_prem
+   ~load_maint_sa
+   ~load_maint_sa2
+
+
+Surrender Charges
+^^^^^^^^^^^^^^^^^
+
+The per-policy initial surrender charge rate and the raw
+``ProductSpecTable`` parameters it is built from.
+
+.. autosummary::
+
+   ~init_surr_charge
+   ~surr_charge_param1
+   ~surr_charge_param2
+
+
+Misc
+^^^^
+
+Placeholder cells reserved for future use.
+
+.. warning::
+
+   :func:`gross_prem_table`, :func:`reserve_rate` and
+   :func:`uern_prem_rate` are placeholders that currently return
+   ``None`` and are to be implemented.
+
+.. autosummary::
+
+   ~gross_prem_table
+   ~reserve_rate
+   ~uern_prem_rate
+
+"""
+
+from modelx.serialize.jsonvalues import *
+
+_formula = None
+
+_bases = [
+    ".Utilities"
+]
+
+_allow_none = None
+
+_spaces = []
+
+# ---------------------------------------------------------------------------
+# Cells
+
+def gross_prem_table():
+    """Gross premium table"""
+    return None
+
+
+def init_surr_charge():
+    """Initial Surrender Charge Rate"""
+
+    param1 = surr_charge_param1()
+    param2 = surr_charge_param2()
+
+    return param1 + param2 * np.minimum(policy_term() / 10, 1)
+
+
+def int_rate(basis):
+    """Interest Rate"""
+
+    col = {
+        RateBasisID.PREM: 'IntRatePrem',
+        RateBasisID.VAL: 'IntRateVal'}.get(basis, None)
+
+    return pandas_to_array(
+        map_to_policies(input_data.product_spec(col)))
+
+
+def load_acq_sa():
+    """Acquisition Loading per Sum Assured"""
+    param1 = load_acq_sa_param1()
+    param2 = load_acq_sa_param2()
+
+    return param1 + param2 * np.minimum(policy_term() / 10, 1)
+
+
+def load_maint_prem():
+    """Maintenance Loading per Gross Premium"""
+
+    param1 = load_maint_prem_param1()
+    param2 = load_maint_prem_param2()
+
+    return np.where(np.isnan(param1), (param2 + np.minimum(10, policy_term())) / 100, param1)
+
+
+def load_maint_prem_waiver_prem():
+    """Maintenance Loading per Gross Premium for Premium Waiver"""
+
+    table = input_data.prem_waiver_cost()
+
+    bins = [-np.inf] + list(table.keys())[:-1] + [np.inf]
+    vals = list(table.values())
+
+    return pandas_to_array(pd.cut(
+         input_data.policy_data()['PolicyTerm'],
+         bins=bins,
+         labels=vals,
+         right=False,        # left-closed: [x, y)
+     ))
+
+
+def load_maint_sa():
+    """Maintenance Loading per Sum Assured during Premium Payment"""
+
+    return pandas_to_array(
+        map_to_policies(input_data.product_spec('LoadMaintSA')))
+
+
+def load_maint_sa2():
+    """Maintenance Loading per Sum Assured during Premium Payment"""
+
+    return pandas_to_array(
+        map_to_policies(input_data.product_spec('LoadMaintSA2')))
+
+
+def reserve_rate():
+    """Valuation Reserve Rate per Sum Assured"""
+    return None
+
+
+def table_id(basis):
+    """Mortality Table ID"""
+
+    col = {
+        RateBasisID.PREM: 'MortTablePrem',
+        RateBasisID.VAL: 'MortTableVal'}.get(basis, None)
+
+    return pandas_to_array(
+        map_to_policies(input_data.product_spec(col)))
+
+
+def uern_prem_rate():
+    """Unearned Premium Rate"""
+    return None
+
+
+def product():
+    """Per-policy product type as a :mod:`~annuallife.TradLife_A.Enums.ProductID` code."""
+    return pandas_to_array(input_data.policy_data()['Product'].map(lambda s: getattr(ProductID, s)))
+
+
+def policy_type():
+    """Per-policy policy type from the ``PolType`` column of :func:`~annuallife.TradLife_A.InputData.policy_data`."""
+    return pandas_to_array(input_data.policy_data()['PolType'])
+
+
+def gen():
+    """Per-policy generation (cohort) identifier."""
+    return PolicyData[idx, 'Gen']
+
+
+def channel():
+    """Per-policy distribution channel."""
+    return PolicyData[idx, 'Channel']
+
+
+def sex():
+    """Per-policy sex as a :mod:`~annuallife.TradLife_A.Enums.SexID` code."""
+    return pandas_to_array(input_data.policy_data()['Sex'].map(lambda s: getattr(SexID, s)))
+
+
+def duration():
+    """Per-policy elapsed policy duration in years."""
+    return PolicyData[idx, 'Duration']
+
+
+def issue_age():
+    """Per-policy issue age in years."""
+    return pandas_to_array(input_data.policy_data()['IssueAge'])
+
+
+def prem_freq():
+   """Per-policy premium payment frequency (number of payments per year)."""
+   return pandas_to_array(input_data.policy_data()['PremFreq'])
+
+
+def policy_term():
+    """Per-policy policy term in years."""
+    return pandas_to_array(input_data.policy_data()['PolicyTerm'])
+
+
+def policy_count():
+    """Per-policy number of policies in the model point."""
+    return pandas_to_array(input_data.policy_data()['PolicyCount'])
+
+
+def sum_assured():
+    """Per-policy sum assured."""
+    return pandas_to_array(input_data.policy_data()['SumAssured'])
+
+
+def load_acq_sa_param1():
+    """Per-policy ``LoadAcqSAParam1`` parameter from ``ProductSpecTable``."""
+    return pandas_to_array(
+        map_to_policies(input_data.product_spec('LoadAcqSAParam1')))
+
+
+def load_acq_sa_param2():
+    """Per-policy ``LoadAcqSAParam2`` parameter from ``ProductSpecTable``."""
+    return pandas_to_array(
+        map_to_policies(input_data.product_spec('LoadAcqSAParam2')))
+
+
+def load_maint_prem_param1():
+    """Per-policy ``LoadMaintPremParam1`` parameter from ``ProductSpecTable``."""
+    return pandas_to_array(
+        map_to_policies(input_data.product_spec('LoadMaintPremParam1')))
+
+
+def load_maint_prem_param2():
+    """Per-policy ``LoadMaintPremParam2`` parameter from ``ProductSpecTable``."""
+    return pandas_to_array(
+        map_to_policies(input_data.product_spec('LoadMaintPremParam2')))
+
+
+def surr_charge_param1():
+    """Per-policy ``SurrChargeParam1`` parameter from ``ProductSpecTable``."""
+    return pandas_to_array(
+        map_to_policies(input_data.product_spec('SurrChargeParam1')))
+
+
+def surr_charge_param2():
+    """Per-policy ``SurrChargeParam2`` parameter from ``ProductSpecTable``."""
+    return pandas_to_array(
+        map_to_policies(input_data.product_spec('SurrChargeParam2')))
+
+
+# ---------------------------------------------------------------------------
+# References
+
+input_data = ("Interface", ("..", "InputData"), "auto")
+
+prem_term = ("Interface", (".", "policy_term"), "auto")
+
+return_array = True

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/Projection/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/Projection/__init__.py
@@ -1,0 +1,58 @@
+"""Per-policy cashflow projection and present values for one model point and scenario.
+
+This is the user-facing Space of :mod:`~annuallife.TradLife_A`: each
+ItemSpace ``Projection[idx, scen_id]`` projects the cashflows and
+their present values for one policy under one scenario.
+
+.. rubric:: Inheritance Structure
+
+The ``Projection`` Space inherits its contents from its base Spaces,
+:mod:`~annuallife.TradLife_A.BaseProj` and
+:mod:`~annuallife.TradLife_A.PV`.
+The projection cells are inherited from
+:mod:`~annuallife.TradLife_A.BaseProj`, and the present values of those
+cashflow items are inherited from :mod:`~annuallife.TradLife_A.PV`.
+
+Parameters and References
+-------------------------
+
+This Space is parameterized with ``idx`` and ``scen_id``::
+
+    >>> m.Projection.parameters
+    ('idx', 'scen_id')
+
+Calling this Space with a pair of integers returns the ItemSpace for
+the policy index and scenario ID. ``scen_id`` has a default value of 1,
+so for example ``Projection[0]`` represents the Projection Space for
+the first policy under scenario 1.
+
+Attributes:
+    idx(:obj:`int`): 0-based policy index into the policy data array.
+    scen_id(:obj:`int`, optional): Scenario ID, defaults to 1.
+
+.. rubric:: References
+
+The following references are inherited from
+:mod:`~annuallife.TradLife_A.BaseProj`:
+
+Attributes:
+    pol: Alias for :mod:`~annuallife.TradLife_A.PolicyAttrs`.
+    asmp: Alias for :mod:`~annuallife.TradLife_A.Assumptions`.
+    scen: Alias for :mod:`~annuallife.TradLife_A.Economic`.
+    comm_table: Alias for :mod:`~annuallife.TradLife_A.CommTable`.
+
+"""
+
+from modelx.serialize.jsonvalues import *
+
+_formula = lambda idx, scen_id=1: None
+
+_bases = [
+    ".BaseProj",
+    ".PV"
+]
+
+_allow_none = None
+
+_spaces = []
+

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/Utilities/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/Utilities/__init__.py
@@ -1,0 +1,83 @@
+"""Helper cells shared by :mod:`~annuallife.TradLife_A.Assumptions` and
+:mod:`~annuallife.TradLife_A.PolicyAttrs`.
+
+This Space is used as a base Space (``_bases``) for
+:mod:`~annuallife.TradLife_A.Assumptions` and
+:mod:`~annuallife.TradLife_A.PolicyAttrs`, which both derive their
+per-policy values by mapping pandas tables onto the rows of the policy
+data.
+
+The cells in this Space rely on a ``return_array`` reference, which is
+defined by the inheriting space (``True`` to convert results to NumPy
+arrays, ``False`` to keep them as pandas objects).
+
+
+Cells Summary
+-------------
+
+Helpers that convert pandas objects to per-policy NumPy arrays and
+reindex assumption tables onto the policy data.
+
+.. autosummary::
+
+   ~pandas_to_array
+   ~map_to_policies
+
+"""
+
+from modelx.serialize.jsonvalues import *
+
+_formula = None
+
+_bases = []
+
+_allow_none = None
+
+_spaces = []
+
+# ---------------------------------------------------------------------------
+# Cells
+
+def pandas_to_array(df_or_series):
+    """Return ``df_or_series`` as a NumPy array or as is.
+
+    If the inheriting space sets ``return_array = True`` (the default
+    for :mod:`~annuallife.TradLife_A.Assumptions` and
+    :mod:`~annuallife.TradLife_A.PolicyAttrs`), the input is converted
+    via :meth:`~pandas.Series.to_numpy`. Otherwise the original pandas
+    object is returned unchanged.
+
+    This is an uncached cell, so it is recomputed on every call.
+    """
+    return df_or_series.to_numpy() if return_array else df_or_series
+
+
+_is_cached = False
+
+def map_to_policies(series):
+    """Reindex an assumption ``series`` to one entry per policy.
+
+    Looks up the values of ``series`` for each row of
+    :func:`~annuallife.TradLife_A.InputData.policy_data` using the
+    columns identified by ``series.index.names`` (e.g. ``Product``,
+    ``PolType``, ``Gen``), and returns a Series whose index matches
+    ``policy_data`` so it aligns with the per-policy NumPy arrays used
+    elsewhere in the model.
+
+    This is an uncached cell, so it is recomputed on every call.
+    """
+    index_names = series.index.names
+    target = input_data.policy_data()[index_names]
+
+    if isinstance(series.index, pd.MultiIndex):
+        new_index = pd.MultiIndex.from_frame(target)
+    else:
+        new_index = pd.Index(target.iloc[:, 0], name=index_names[0])
+
+    result = series.reindex(new_index)
+    result.index = target.index
+    return result
+
+
+_is_cached = False
+

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/__init__.py
@@ -1,0 +1,347 @@
+"""Annual new business projection model of basic traditional life policies.
+
+Overview
+--------
+
+:mod:`~annuallife.TradLife_A` is an annual new business projection model
+of basic traditional life policies, covering term, whole life and
+endowment products, built with
+`modelx <https://modelx.io/>`__.
+
+It projects liability cashflows and their present values for policies
+represented by model points. Projected items include:
+
+* Premiums,
+* Commissions and expenses,
+* Claims.
+
+Premiums are calculated using commutation functions. Cells for investment
+income reserves are defined but not implemented.
+
+Computation flow
+^^^^^^^^^^^^^^^^
+
+Model point data, product specifications, assumptions and economic
+scenarios are all held in an external Excel workbook, *input.xlsx*.
+
+The spaces are wired together as shown below, and the computation
+proceeds as follows.
+
+.. mermaid::
+
+    graph LR
+        Projection --> Economic
+        Projection --> Assumptions
+        Projection --> PolicyAttrs
+        Projection --> CommTable
+        Economic --> InputData
+        Assumptions --> InputData
+        PolicyAttrs --> InputData
+        CommTable --> InputData
+
+* The data is read into the model from the input file in
+  :mod:`~annuallife.TradLife_A.InputData`, and held there as
+  :mod:`pandas` DataFrames and dicts.
+* :mod:`~annuallife.TradLife_A.InputData` is referenced by
+  :mod:`~annuallife.TradLife_A.PolicyAttrs` and
+  :mod:`~annuallife.TradLife_A.Assumptions`, where policy attributes and
+  assumptions are mapped to model points.
+* :mod:`~annuallife.TradLife_A.InputData` is also referenced by
+  :mod:`~annuallife.TradLife_A.Economic`, where discount rates are
+  calculated.
+* :mod:`~annuallife.TradLife_A.CommTable` calculates commutation
+  functions, and defines actuarial notations. They are used by
+  :mod:`~annuallife.TradLife_A.Projection` to calculate the premium rate
+  for each model point. Mortality rates are provided through
+  :mod:`~annuallife.TradLife_A.InputData`.
+  :mod:`~annuallife.TradLife_A.CommTable` takes three parameters,
+  ``Sex``, ``IntRate`` and ``Table`` (sex, interest rate and mortality
+  table id).
+* :mod:`~annuallife.TradLife_A.Projection` carries out the projection by
+  model point. It takes two parameters: ``idx`` (mandatory) to identify
+  a model point, and ``scen_id`` (optional) to select the economic
+  scenario, defaulting to 1. Policy attributes and assumptions are
+  received from cells in
+  :mod:`~annuallife.TradLife_A.PolicyAttrs` and
+  :mod:`~annuallife.TradLife_A.Assumptions`, which return their values by
+  model point in 1-D :mod:`numpy` arrays, so the ``idx`` parameter
+  indicates the array index, starting from 0.
+* The projection logic is not defined directly in
+  :mod:`~annuallife.TradLife_A.Projection`. Instead, the space inherits
+  all of its logic from two base spaces,
+  :mod:`~annuallife.TradLife_A.BaseProj` and
+  :mod:`~annuallife.TradLife_A.PV`.
+
+For example, the present value of net cashflows for the first model
+point is obtained as::
+
+    >>> m.Projection[0].pv_net_cf(0)
+
+Model Structure
+---------------
+
+In :mod:`~annuallife.TradLife_A`, the following spaces are defined.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Space
+     - Description
+   * - :mod:`~annuallife.TradLife_A.InputData`
+     - Reads *input.xlsx* and holds its named ranges as :mod:`pandas`
+       DataFrames and dicts.
+   * - :mod:`~annuallife.TradLife_A.Economic`
+     - Parametric space holding scenario-dependent economic assumptions;
+       parameter ``scen_id``.
+   * - :mod:`~annuallife.TradLife_A.BaseProj`
+     - Base space of :mod:`~annuallife.TradLife_A.Projection` containing
+       the cells that produce the per-period cashflow projections.
+   * - :mod:`~annuallife.TradLife_A.PV`
+     - Base space of :mod:`~annuallife.TradLife_A.Projection` containing
+       the cells that compute the present values of those cashflows.
+   * - :mod:`~annuallife.TradLife_A.Projection`
+     - Parametric space whose dynamic ItemSpaces carry out projections
+       for each model point; parameters ``idx`` and ``scen_id``.
+   * - :mod:`~annuallife.TradLife_A.Assumptions`
+     - Holds assumption parameters and rates used by
+       :mod:`~annuallife.TradLife_A.Projection`.
+   * - :mod:`~annuallife.TradLife_A.PolicyAttrs`
+     - Holds policy attributes and policy-level values such as premium
+       and surrender rates used by
+       :mod:`~annuallife.TradLife_A.Projection`.
+   * - :mod:`~annuallife.TradLife_A.Utilities`
+     - Base space of :mod:`~annuallife.TradLife_A.Assumptions` and
+       :mod:`~annuallife.TradLife_A.PolicyAttrs` providing helper cells.
+   * - :mod:`~annuallife.TradLife_A.CommTable`
+     - Parametric space providing commutation functions and actuarial
+       notations; parameters ``Sex``, ``IntRate`` and ``Table``.
+   * - :mod:`~annuallife.TradLife_A.Enums`
+     - Container for the enum types used across the model.
+
+:mod:`~annuallife.TradLife_A.Enums` contains the enum types as child
+spaces, and :mod:`~annuallife.TradLife_A.Assumptions` contains an
+``AsmpID`` child space.
+
+Inheritance
+^^^^^^^^^^^
+
+:mod:`~annuallife.TradLife_A.Projection` inherits from
+:mod:`~annuallife.TradLife_A.BaseProj` and
+:mod:`~annuallife.TradLife_A.PV`, so projection cells and their
+present-value counterparts share the same parameter scope.
+
+.. mermaid::
+
+    %%{init: {"class": {"hideEmptyMembersBox": true}}}%%
+    classDiagram
+        BaseProj <|-- Projection
+        PV <|-- Projection
+
+:mod:`~annuallife.TradLife_A.Assumptions` and
+:mod:`~annuallife.TradLife_A.PolicyAttrs` inherit from
+:mod:`~annuallife.TradLife_A.Utilities`, which contributes the
+``pandas_to_array`` and ``map_to_policies`` helpers.
+
+.. mermaid::
+
+    %%{init: {"class": {"hideEmptyMembersBox": true}}}%%
+    classDiagram
+        Utilities <|-- Assumptions
+        Utilities <|-- PolicyAttrs
+
+Cross-space references
+^^^^^^^^^^^^^^^^^^^^^^
+
+The cells in :mod:`~annuallife.TradLife_A.Projection` and its base
+spaces resolve a number of References to other spaces:
+
+* ``scen`` -> :mod:`~annuallife.TradLife_A.Economic`
+* ``asmp`` -> :mod:`~annuallife.TradLife_A.Assumptions`
+* ``pol`` -> :mod:`~annuallife.TradLife_A.PolicyAttrs`
+* ``comm_table`` -> :mod:`~annuallife.TradLife_A.CommTable`
+
+:mod:`~annuallife.TradLife_A.Economic`,
+:mod:`~annuallife.TradLife_A.Assumptions` and
+:mod:`~annuallife.TradLife_A.PolicyAttrs` each reference the
+:mod:`~annuallife.TradLife_A.InputData` space as ``input_data``, while
+:mod:`~annuallife.TradLife_A.CommTable` references the
+:func:`~annuallife.TradLife_A.InputData.mortality_tables` cells defined
+in :mod:`~annuallife.TradLife_A.InputData` as ``mortality_tables``.
+
+.. mermaid::
+
+    graph LR
+        Projection -- scen --> Economic
+        Projection -- asmp --> Assumptions
+        Projection -- pol --> PolicyAttrs
+        Projection -- comm_table --> CommTable
+        Economic -- input_data --> InputData
+        Assumptions -- input_data --> InputData
+        PolicyAttrs -- input_data --> InputData
+        CommTable -- mortality_tables --> InputData
+
+Input File
+----------
+
+:mod:`~annuallife.TradLife_A` reads its data from *input.xlsx*, which is
+located next to the *TradLife_A* model directory inside the library
+folder. The default file name is set by the
+:attr:`~annuallife.TradLife_A.InputData.input_file_name` reference.
+
+The workbook defines the following named ranges, picked up through cells
+in :mod:`~annuallife.TradLife_A.InputData`:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 40 35
+
+   * - External named range
+     - Cells
+     - Purpose
+   * - ``PolicyData``
+     - :func:`~annuallife.TradLife_A.InputData.policy_data`
+     - Per-policy attributes for model points
+   * - ``ProductSpecTable``
+     - :func:`~annuallife.TradLife_A.InputData.product_spec`
+     - Per-product loading and rate tables
+   * - ``AssumptionTable``
+     - :func:`~annuallife.TradLife_A.InputData.assumption`
+     - Lookup table of assumption keys
+   * - ``AsmpByDuration``
+     - :func:`~annuallife.TradLife_A.InputData.assumption_tables`
+     - Duration-based mortality / lapse tables
+   * - ``MortalityTables``
+     - :func:`~annuallife.TradLife_A.InputData.mortality_tables`
+     - Mortality tables keyed by Sex / Table
+   * - ``Scenarios``
+     - :func:`~annuallife.TradLife_A.InputData.scenarios`
+     - Scenario interest-rate paths
+   * - ``LargePolDiscount``
+     - :func:`~annuallife.TradLife_A.InputData.discount_rate`
+     - Premium discount by sum-assured band
+   * - ``PremiumWaiverCost``
+     - :func:`~annuallife.TradLife_A.InputData.prem_waiver_cost`
+     - Premium-waiver cost lookup
+   * - ``ConstParams``
+     - :func:`~annuallife.TradLife_A.InputData.const_params`
+     - Scalar parameters used across the model
+
+.. _tradlife_a-basic-usage:
+
+Basic Usage
+-----------
+
+Reading the model
+^^^^^^^^^^^^^^^^^
+
+Create your copy of the *annuallife* library by following the steps on
+the :doc:`/quickstart/index` page. The model is saved as the folder
+``TradLife_A`` in the copied folder, with *input.xlsx* placed next to
+it.
+
+To read the model from Spyder with the modelx plug-in, right-click on
+the empty space in *MxExplorer*, select *Read Model*, and choose the
+*TradLife_A* folder.
+
+To read the model on an IPython console, use ``read_model`` after
+changing the current directory to the library folder so the workbook is
+discoverable:
+
+.. code-block:: python
+
+    >>> import modelx as mx
+
+    >>> m = mx.read_model("TradLife_A")
+
+Running results
+^^^^^^^^^^^^^^^
+
+Projection results are obtained by calling the cells of an ItemSpace of
+:mod:`~annuallife.TradLife_A.Projection` with a specific ``idx`` (and
+optionally ``scen_id``):
+
+.. code-block:: python
+
+    >>> m.Projection[0].pv_net_cf(0)            # PV of net cashflow at t=0
+    >>> m.Projection[0].net_cf(5)               # Net cashflow at t=5
+    >>> m.Projection[0].premiums(0)             # Premium income at t=0
+    >>> m.Projection[0].claims(0)               # Death claims at t=0
+
+The plot scripts ``plot_tradlife_a.py`` and ``plot_pvcashflows_tradlife_a.py``
+in the library folder demonstrate how to produce stacked-bar charts of
+the cashflow components and their present values.
+
+Exporting the model
+^^^^^^^^^^^^^^^^^^^
+
+The model can be exported to a pure-Python (nomx) module that does not
+depend on modelx. Use the ``export`` method on the model object::
+
+    >>> m.export("TradLife_A_nomx")
+
+This command exports the model as a Python package named
+``TradLife_A_nomx`` in the current directory. You can test the exported
+(nomx) model by importing it and accessing its cells::
+
+    >>> from TradLife_A_nomx import mx_model
+
+    >>> mx_model.Projection[0].pv_net_cf(0)
+
+(Here, ``mx_model`` is the nomx model object.)
+
+Global References
+-----------------
+
+Global references are names that can be referenced from formulas in any
+space in the model. The third-party modules
+`pandas <https://pandas.pydata.org/>`__ and
+`numpy <https://numpy.org/>`__ are defined here, as are the enum types
+defined as child spaces under :mod:`~annuallife.TradLife_A.Enums`.
+
+Attributes:
+    pd: The `pandas <https://pandas.pydata.org/>`__ module.
+    np: The `numpy <https://numpy.org/>`__ module.
+    ProductID: The product-type enum,
+        :mod:`~annuallife.TradLife_A.Enums.ProductID` (``TERM`` term
+        insurance, ``WL`` whole life, ``ENDW`` endowment).
+    SexID: The sex enum,
+        :mod:`~annuallife.TradLife_A.Enums.SexID` (``M`` male,
+        ``F`` female).
+    RateBasisID: The rate-basis enum,
+        :mod:`~annuallife.TradLife_A.Enums.RateBasisID` (``PREM`` premium
+        basis, ``VAL`` valuation basis).
+
+"""
+
+from modelx.serialize.jsonvalues import *
+
+_name = "TradLife_A"
+
+_allow_none = False
+
+_spaces = [
+    "InputData",
+    "Economic",
+    "BaseProj",
+    "PV",
+    "Projection",
+    "Assumptions",
+    "PolicyAttrs",
+    "Utilities",
+    "CommTable",
+    "Enums"
+]
+
+# ---------------------------------------------------------------------------
+# References
+
+pd = ("Module", "pandas")
+
+np = ("Module", "numpy")
+
+ProductID = ("Interface", (".", "Enums", "ProductID"), "None")
+
+SexID = ("Interface", (".", "Enums", "SexID"), "None")
+
+RateBasisID = ("Interface", (".", "Enums", "RateBasisID"), "None")

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/_system.json
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/_system.json
@@ -1,0 +1,1 @@
+{"modelx_version": [0, 31, 0], "serializer_version": 6}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "modelx>=0.26.0",
+    "modelx>=0.31.0",
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['modelx>=0.26.0'],
+    install_requires=['modelx>=0.31.0'],
 
     # If your project only runs on certain Python versions,
     # setting the python_requires argument to the appropriate PEP 440 version


### PR DESCRIPTION
## Summary

`TradLife_A` (in the `annuallife` library) is serialized in modelx
**serializer version 7**, introduced by **modelx 0.31.0**. modelx older
than 0.31.0 cannot read serializer-v7 models, so those users currently
cannot open `TradLife_A` at all.

This PR:

* Bumps the required `modelx` version to **`>=0.31.0`** in
  `pyproject.toml`, `setup.py`, and `.github/copilot-instructions.md`.
* Adds **`TradLife_A_mx30`**, a copy of `TradLife_A` re-serialized with
  **serializer version 6**, to the `annuallife` library as a fallback
  for users whose `modelx` is older than 0.31.0. It is the same model
  and reads from the same `input.xlsx`.
* Documents both in the v0.12 release notes and on the `annuallife`
  library doc page (new "Older modelx versions" section + Library
  Contents table row).

## How the copy was generated

```python
import modelx as mx
m = mx.read_model("TradLife_A")
mx.write_model(m, "TradLife_A_mx30", version=6)
```

Resulting `TradLife_A_mx30/_system.json`:
`{"modelx_version": [0, 31, 0], "serializer_version": 6}`.

## Verification

* `TradLife_A_mx30/_system.json` confirmed `serializer_version: 6`.
* Equivalence: `Projection[170].pv_net_cf[0..49]` is identical between
  `TradLife_A` and `TradLife_A_mx30` (max abs diff `0.0`).
* No `modelx>=0.26.0` remains in the tree.

Note: only modelx 0.31.0 was available locally, so "an older modelx
opens the copy" was not tested directly — correctness rests on the
serializer-v6 marker plus the equivalence check (modelx 0.31.0 reads
v6 models too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)