### PR TITLE
DIST: Release v0.12.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ By using lifelib, you can enjoy the following advantages:
 
 License
 -------
-Copyright (c) 2018-2025 lifelib Developers
+Copyright (c) 2018-2026 lifelib Developers
 
 lifelib is free software; you can redistribute it and/or
 modify it under the terms of

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -67,7 +67,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'lifelib'
-copyright = '2018-2025, lifelib Developers'
+copyright = '2018-2026, lifelib Developers'
 author = 'lifelib Developers'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/lifelib/__init__.py
+++ b/lifelib/__init__.py
@@ -1,7 +1,7 @@
 import os.path
 from lifelib.commands.create import create
 
-VERSION = (0, 11, 0)
+VERSION = (0, 12, 0)
 __version__ = '.'.join([str(x) for x in VERSION])
 
 


### PR DESCRIPTION
## Summary

- Bump package version `0.11.0` → `0.12.0` in `lifelib/__init__.py` (single source of truth; `__version__` and the Sphinx docs derive from it)
- Refresh copyright year `2018-2025` → `2018-2026` in `README.rst` and `doc/source/conf.py`, mirroring prior release commits

## Why

The v0.12.0 release notes were already added in `77ba074`, but the package still reported `0.11.0`. This cuts the release commit following the project's established `DIST: Release vX.Y.Z` convention (cf. `8484dac DIST: Release v0.11.0`).

## Notes for reviewers

- Exactly 3 files changed, 3 insertions / 3 deletions — same shape as the v0.11.0 release commit
- Verified: `import lifelib; lifelib.__version__` → `0.12.0`
- `doc/source/conf.py` reads `lifelib.__version__` dynamically, so no hardcoded version needed updating there

🤖 Generated with [Claude Code](https://claude.com/claude-code)