### PR TITLE
TradLife_A: move return_array reference to Utilities base space

### DIFF
--- a/lifelib/libraries/annuallife/TradLife_A/Assumptions/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Assumptions/__init__.py
@@ -27,17 +27,13 @@ Attributes:
         :func:`~annuallife.TradLife_A.InputData.assumption_tables` and
         :func:`~annuallife.TradLife_A.InputData.mortality_tables`.
 
-    return_array(:obj:`bool`): When ``True`` (the default), helper
-        functions inherited from
-        :mod:`~annuallife.TradLife_A.Utilities` return NumPy arrays
-        instead of pandas objects.
-
 .. rubric:: Inherited helpers
 
 Inherited from :mod:`~annuallife.TradLife_A.Utilities`:
 
 * :func:`~annuallife.TradLife_A.Utilities.pandas_to_array`
 * :func:`~annuallife.TradLife_A.Utilities.map_to_policies`
+* :attr:`~annuallife.TradLife_A.Utilities.return_array`
 
 .. rubric:: Child spaces
 
@@ -292,5 +288,3 @@ def asmp_table_len():
 # References
 
 input_data = ("Interface", ("..", "InputData"), "auto")
-
-return_array = True

--- a/lifelib/libraries/annuallife/TradLife_A/PolicyAttrs/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/PolicyAttrs/__init__.py
@@ -31,10 +31,6 @@ Attributes:
         and product specs from
         :func:`~annuallife.TradLife_A.InputData.product_spec`.
     prem_term: Alias for :func:`policy_term`.
-    return_array(:obj:`bool`): When ``True`` (the default), helper
-        functions inherited from
-        :mod:`~annuallife.TradLife_A.Utilities` return NumPy arrays
-        instead of pandas objects.
 
 .. rubric:: Inherited helpers
 
@@ -42,6 +38,7 @@ Inherited from :mod:`~annuallife.TradLife_A.Utilities`:
 
 * :func:`~annuallife.TradLife_A.Utilities.pandas_to_array`
 * :func:`~annuallife.TradLife_A.Utilities.map_to_policies`
+* :attr:`~annuallife.TradLife_A.Utilities.return_array`
 
 
 Cells Summary
@@ -335,5 +332,3 @@ def surr_charge_param2():
 input_data = ("Interface", ("..", "InputData"), "auto")
 
 prem_term = ("Interface", (".", "policy_term"), "auto")
-
-return_array = True

--- a/lifelib/libraries/annuallife/TradLife_A/Utilities/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Utilities/__init__.py
@@ -12,9 +12,15 @@ This Space is used as a base Space (``_bases``) for
 per-policy values by mapping pandas tables onto the rows of the policy
 data.
 
-The cells in this Space rely on a ``return_array`` reference, which is
-defined by the inheriting space (``True`` to convert results to NumPy
-arrays, ``False`` to keep them as pandas objects).
+Parameters and References
+-------------------------
+
+Attributes:
+    return_array(:obj:`bool`): When ``True`` (the default), helper
+        functions defined in this Space return NumPy arrays instead of
+        pandas objects. Inherited by
+        :mod:`~annuallife.TradLife_A.Assumptions` and
+        :mod:`~annuallife.TradLife_A.PolicyAttrs`.
 
 
 Cells Summary
@@ -86,3 +92,7 @@ def map_to_policies(series):
 
 _is_cached = False
 
+# ---------------------------------------------------------------------------
+# References
+
+return_array = True

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/Assumptions/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/Assumptions/__init__.py
@@ -22,17 +22,13 @@ Attributes:
         :func:`~annuallife.TradLife_A.InputData.assumption_tables` and
         :func:`~annuallife.TradLife_A.InputData.mortality_tables`.
 
-    return_array(:obj:`bool`): When ``True`` (the default), helper
-        functions inherited from
-        :mod:`~annuallife.TradLife_A.Utilities` return NumPy arrays
-        instead of pandas objects.
-
 .. rubric:: Inherited helpers
 
 Inherited from :mod:`~annuallife.TradLife_A.Utilities`:
 
 * :func:`~annuallife.TradLife_A.Utilities.pandas_to_array`
 * :func:`~annuallife.TradLife_A.Utilities.map_to_policies`
+* :attr:`~annuallife.TradLife_A.Utilities.return_array`
 
 .. rubric:: Child spaces
 
@@ -287,5 +283,3 @@ def asmp_table_len():
 # References
 
 input_data = ("Interface", ("..", "InputData"), "auto")
-
-return_array = True

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/PolicyAttrs/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/PolicyAttrs/__init__.py
@@ -26,10 +26,6 @@ Attributes:
         and product specs from
         :func:`~annuallife.TradLife_A.InputData.product_spec`.
     prem_term: Alias for :func:`policy_term`.
-    return_array(:obj:`bool`): When ``True`` (the default), helper
-        functions inherited from
-        :mod:`~annuallife.TradLife_A.Utilities` return NumPy arrays
-        instead of pandas objects.
 
 .. rubric:: Inherited helpers
 
@@ -37,6 +33,7 @@ Inherited from :mod:`~annuallife.TradLife_A.Utilities`:
 
 * :func:`~annuallife.TradLife_A.Utilities.pandas_to_array`
 * :func:`~annuallife.TradLife_A.Utilities.map_to_policies`
+* :attr:`~annuallife.TradLife_A.Utilities.return_array`
 
 
 Cells Summary
@@ -332,5 +329,3 @@ def surr_charge_param2():
 input_data = ("Interface", ("..", "InputData"), "auto")
 
 prem_term = ("Interface", (".", "policy_term"), "auto")
-
-return_array = True

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/Utilities/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/Utilities/__init__.py
@@ -7,9 +7,15 @@ This Space is used as a base Space (``_bases``) for
 per-policy values by mapping pandas tables onto the rows of the policy
 data.
 
-The cells in this Space rely on a ``return_array`` reference, which is
-defined by the inheriting space (``True`` to convert results to NumPy
-arrays, ``False`` to keep them as pandas objects).
+Parameters and References
+-------------------------
+
+Attributes:
+    return_array(:obj:`bool`): When ``True`` (the default), helper
+        functions defined in this Space return NumPy arrays instead of
+        pandas objects. Inherited by
+        :mod:`~annuallife.TradLife_A.Assumptions` and
+        :mod:`~annuallife.TradLife_A.PolicyAttrs`.
 
 
 Cells Summary
@@ -81,3 +87,7 @@ def map_to_policies(series):
 
 _is_cached = False
 
+# ---------------------------------------------------------------------------
+# References
+
+return_array = True


### PR DESCRIPTION
## Summary

- `Assumptions` and `PolicyAttrs` both inherit from the shared `Utilities` base space and each defined its own `return_array = True` reference. Moved the reference up to `Utilities` so it lives on the base only.
- Updated the `Utilities` docstring with a new "Parameters and References" section documenting `return_array`.
- In the child docstrings, removed the `return_array` entry from the `Attributes:` block and added `:attr:`~annuallife.TradLife_A.Utilities.return_array`` to the existing "Inherited helpers" bullet list.

No behavior change — children still see `return_array == True` via inheritance.

## Test plan

- [x] `mx.read_model('lifelib/libraries/annuallife/TradLife_A')` succeeds.
- [x] `m.Utilities.return_array`, `m.Assumptions.return_array`, `m.PolicyAttrs.return_array` all resolve to `True`.
- [x] `m.Assumptions.comm_init_prem()` and `m.PolicyAttrs.product()` still return NumPy arrays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)