### PR TITLE
DOC: Fix mermaid diagram rendering in TradLife_A Assumptions docstring

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -280,5 +280,11 @@ nbsphinx_requirejs_path = ''
 # its hideEmptyMembersBox option require >= 11.4.0.
 mermaid_version = "11.4.1"
 
+# sphinxcontrib-mermaid 2.0.x forces svg { height: 500px; width: 100% }, which
+# stretches the SVG to a 500px height regardless of content. Letting height
+# auto-size preserves the natural aspect ratio so labels stay inside their
+# rectangles.
+mermaid_height = "auto"
+
 def setup(app):
     app.add_css_file("custom-style.css")

--- a/lifelib/libraries/annuallife/TradLife_A/Assumptions/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Assumptions/__init__.py
@@ -40,8 +40,8 @@ following pipeline:
 
     graph LR
         A["input_data.assumption(key)<br/>pandas Series keyed by<br/>(Product, PolType, Gen)"]
-        --> B["map_to_policies<br/>reindex onto policy_data rows"]
-        B --> C["pandas_to_array<br/>convert when return_array=True"]
+        --> B["map_to_policies<br/>reindex onto<br/>policy_data rows"]
+        B --> C["pandas_to_array<br/>convert when<br/>return_array=True"]
         C --> D["1-D NumPy array<br/>indexed by policy idx"]
 
 For example, :func:`comm_init_prem` is implemented as


### PR DESCRIPTION
## Summary

- Fixes label-text overflow in the pipeline mermaid diagram in `TradLife_A.Assumptions`' docstring (introduced in [#133](https://github.com/lifelib-dev/lifelib/pull/133) / 690de98).
- sphinxcontrib-mermaid 2.0.x injects `pre.mermaid > svg { height: 500px; width: 100% }` on every diagram. Combined with mermaid's HTML `<foreignObject>` labels (which don't scale with the SVG viewport), this stretched the SVG to a fixed 500px height and let long label lines spill past the rectangle borders.
- Two changes restore clean rendering:
  - `doc/source/conf.py`: set `mermaid_height = "auto"` so every mermaid SVG keeps its natural aspect ratio instead of being forced to 500px.
  - `Assumptions/__init__.py`: break the two longer node labels (`map_to_policies` reindex and `pandas_to_array` convert) onto an extra `<br/>` line so each line fits inside mermaid's 200-unit foreignObject wrap width.
- Layout stays `graph LR` (horizontal).

## Test plan

- [x] Built docs locally with `sphinx-build -b html` and viewed `libraries/annuallife/Assumptions.html` in a browser.
- [x] Confirmed all four boxes in the pipeline diagram show their full text inside the rectangle.
- [x] Spot-checked the other three mermaid diagrams in `TradLife_A/__init__.py` to confirm `mermaid_height = "auto"` doesn't break them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)