### PR TITLE
REF: TradLife_A: keep PV outflow cells as positive amounts

### DIFF
--- a/lifelib/libraries/annuallife/TradLife_A/PV/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/PV/__init__.py
@@ -126,7 +126,7 @@ def pv_claims_death(t):
     if t > proj_len():
         return 0
     else:
-        return (-claims_death(t) + pv_claims_death(t+1)) / (1 + disc_rate_mth(t))
+        return (claims_death(t) + pv_claims_death(t+1)) / (1 + disc_rate_mth(t))
 
 
 def pv_claims_mat(t):
@@ -140,7 +140,7 @@ def pv_claims_mat(t):
     if t > proj_len():
         return 0
     else:
-        return (-claims_mat(t) + pv_claims_mat(t+1)) / (1 + disc_rate_mth(t))
+        return (claims_mat(t) + pv_claims_mat(t+1)) / (1 + disc_rate_mth(t))
 
 
 def pv_claims_surr(t):
@@ -154,7 +154,7 @@ def pv_claims_surr(t):
     if t > proj_len():
         return 0
     else:
-        return (-claims_surr(t) + pv_claims_surr(t+1)) / (1 + disc_rate_mth(t))
+        return (claims_surr(t) + pv_claims_surr(t+1)) / (1 + disc_rate_mth(t))
 
 
 def pv_claims(t):
@@ -170,7 +170,7 @@ def pv_claims(t):
     if t > proj_len():
         return 0
     else:
-        return (-claims(t) + pv_claims(t+1)) / (1 + disc_rate_mth(t))
+        return (claims(t) + pv_claims(t+1)) / (1 + disc_rate_mth(t))
 
 
 def pv_check(t):
@@ -198,7 +198,7 @@ def pv_exps_acq(t):
     if t > proj_len():
         return 0
     else:
-        return - exps_acq(t) + pv_exps_acq(t+1) / (1 + disc_rate_mth(t))
+        return exps_acq(t) + pv_exps_acq(t+1) / (1 + disc_rate_mth(t))
 
 
 def pv_commissions(t):
@@ -212,7 +212,7 @@ def pv_commissions(t):
     if t > proj_len():
         return 0
     else:
-        return - commissions(t) + pv_commissions(t+1) / (1 + disc_rate_mth(t))
+        return commissions(t) + pv_commissions(t+1) / (1 + disc_rate_mth(t))
 
 
 def pv_exps_maint(t):
@@ -226,7 +226,7 @@ def pv_exps_maint(t):
     if t > proj_len():
         return 0
     else:
-        return - exps_maint(t) + pv_exps_maint(t+1) / (1 + disc_rate_mth(t))
+        return exps_maint(t) + pv_exps_maint(t+1) / (1 + disc_rate_mth(t))
 
 
 def pv_expenses(t):
@@ -242,7 +242,7 @@ def pv_expenses(t):
     if t > proj_len():
         return 0
     else:
-        return - expenses(t) + pv_expenses(t+1) / (1 + disc_rate_mth(t))
+        return expenses(t) + pv_expenses(t+1) / (1 + disc_rate_mth(t))
 
 
 def pv_net_cf(t):
@@ -258,8 +258,8 @@ def pv_net_cf(t):
         * :func:`interest_net_cf`
     """
     return (pv_premiums(t)
-            + pv_expenses(t)
-            + pv_claims(t))
+            - pv_expenses(t)
+            - pv_claims(t))
 
 
 def pv_net_cf_for_check(t):

--- a/lifelib/libraries/annuallife/plot_pvcashflows_tradlife_a.py
+++ b/lifelib/libraries/annuallife/plot_pvcashflows_tradlife_a.py
@@ -36,4 +36,5 @@ import seaborn as sns
 sns.set_theme(style="darkgrid")
 
 axes = ncf.plot.line(marker='o', color='r')
+cfs[vars[1:]] = cfs[vars[1:]].mul(-1)   # Change outflows to negatives
 cfs.plot(kind='bar', stacked=True, ax=axes)


### PR DESCRIPTION
## Summary

- The PV cells in `TradLife_A.PV` for claims, expenses and commissions previously flipped the sign of the underlying cashflow so that `pv_net_cf` could be computed as a simple sum of `pv_premiums + pv_expenses + pv_claims`. This obscured the fact that those cells represent outflows.
- The PV outflow cells (`pv_claims_death`, `pv_claims_mat`, `pv_claims_surr`, `pv_claims`, `pv_exps_acq`, `pv_commissions`, `pv_exps_maint`, `pv_expenses`) now return the present value of the cashflow as a positive amount.
- `pv_net_cf` is updated to `pv_premiums - pv_expenses - pv_claims`, preserving its numerical value.
- `plot_pvcashflows_tradlife_a.py` now multiplies the outflow PV series by `-1` before stacking, matching the convention already used in `plot_tradlife_a.py` for raw cashflows.

## Why

The previous sign convention conflated "present value of an outflow" with "negative cashflow", which is inconsistent with the rest of the model (e.g. `claims`, `expenses` in `BaseProj` are positive amounts) and makes the cell values harder to interpret on their own.

## Notes for reviewers

- `interest_net_cf`, `pv_net_cf_for_check`, and `pv_check` are unchanged — they either reference raw `BaseProj` cells directly or work with the unchanged net value of `pv_net_cf`.
- Verified locally with policy idx 170: `max abs pv_check` over `t in range(50)` is ~3e-11, and `pv_premiums(0) - pv_expenses(0) - pv_claims(0) == pv_net_cf(0)`.
- The `TradLife_A_mx30` snapshot is intentionally not modified — it is a legacy modelx 3.0 serialization.

## Test plan

- [ ] `pv_check(t)` ~ 0 for `t in range(50)` across a sample policy.
- [ ] `pv_claims(0)`, `pv_expenses(0)` are positive.
- [ ] `pv_net_cf(0)` matches the pre-change value.
- [ ] `plot_pvcashflows_tradlife_a.py` renders outflows as negative bars below the x-axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)