### PR TITLE
DOC: TradLife_A — expand and refine Input File docs

### DIFF
--- a/lifelib/libraries/annuallife/TradLife_A/PolicyAttrs/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/PolicyAttrs/__init__.py
@@ -8,7 +8,7 @@
 This Space holds policy attributes and policy-level values used by
 :mod:`~annuallife.TradLife_A.Projection` and its base spaces.
 
-The main role of this Space is to associate per-policy data sourced
+The main role of this Space is to associate product specs sourced
 from :mod:`~annuallife.TradLife_A.InputData` with the model points
 held in
 :func:`~annuallife.TradLife_A.InputData.policy_data`, and to expose

--- a/lifelib/libraries/annuallife/TradLife_A/Utilities/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Utilities/__init__.py
@@ -58,7 +58,7 @@ def pandas_to_array(df_or_series):
     via :meth:`~pandas.Series.to_numpy`. Otherwise the original pandas
     object is returned unchanged.
 
-    This is an uncached cell, so it is recomputed on every call.
+    This is an uncached Cells, so it is recomputed on every call.
     """
     return df_or_series.to_numpy() if return_array else df_or_series
 
@@ -75,7 +75,7 @@ def map_to_policies(series):
     ``policy_data`` so it aligns with the per-policy NumPy arrays used
     elsewhere in the model.
 
-    This is an uncached cell, so it is recomputed on every call.
+    This is an uncached Cells, so it is recomputed on every call.
     """
     index_names = series.index.names
     target = input_data.policy_data()[index_names]

--- a/lifelib/libraries/annuallife/TradLife_A/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/__init__.py
@@ -203,8 +203,10 @@ through a Cells in :mod:`~annuallife.TradLife_A.InputData`.
    named ranges and the helpers that turn them into :mod:`pandas`
    objects.
 
-``PolicyData``
-^^^^^^^^^^^^^^
+Model point data
+^^^^^^^^^^^^^^^^
+
+Named range: ``PolicyData``
 
 Per-policy attributes for the model points the projection runs over.
 One row per policy, loaded by
@@ -248,8 +250,10 @@ the ``Policy`` column.
    * - ``SumAssured``
      - Sum assured per policy.
 
-``ProductSpecTable``
-^^^^^^^^^^^^^^^^^^^^
+Product specifications
+^^^^^^^^^^^^^^^^^^^^^^
+
+Named range: ``ProductSpecTable``
 
 Per-product specification table holding loading parameters, surrender
 charges and the mortality, interest and lapse references used on the
@@ -264,40 +268,48 @@ each column as a Series keyed by ``Product`` / ``PolType`` / ``Gen``.
    * - Column
      - Description
    * - ``Product``, ``PolType``, ``Gen``
-     - Lookup levels. ``Product`` matches ``Product`` in ``PolicyData``;
+     - Lookup keys. ``Product`` matches ``Product`` in ``PolicyData``;
        ``PolType`` and ``Gen`` are optional refinements and may be left
        blank for product-wide entries.
-   * - ``LoadAcqSAParam1``, ``LoadAcqSAParam2``
-     - Linear parameters of the sum-assured-based acquisition loading
-       (see :func:`~annuallife.TradLife_A.PolicyAttrs.load_acq_sa`).
+   * - ``LoadAcqSAParam<N>``
+     - Linear parameters of the sum-assured-based acquisition loading,
+       with ``N`` = 1, 2 (see
+       :func:`~annuallife.TradLife_A.PolicyAttrs.load_acq_sa`).
    * - ``LoadMaintSA``, ``LoadMaintSA2``
      - Sum-assured-based maintenance loadings during and after the
        premium-paying period.
-   * - ``LoadMaintPremParam1``, ``LoadMaintPremParam2``
-     - Linear parameters of the premium-based maintenance loading
-       (see :func:`~annuallife.TradLife_A.PolicyAttrs.load_maint_prem`).
-   * - ``SurrChargeParam1``, ``SurrChargeParam2``
-     - Parameters of the initial surrender charge (see
-       :func:`~annuallife.TradLife_A.PolicyAttrs.init_surr_charge`).
-   * - ``MortTablePrem``, ``MortTableVal``
-     - Mortality table IDs (columns of ``MortalityTables``) used on the
-       premium and valuation bases.
-   * - ``IntRatePrem``, ``IntRateVal``
-     - Interest rates used on the premium and valuation bases.
-   * - ``LapseRatePrem``, ``LapseRateVal``
-     - Annual lapse rates used on the premium and valuation bases.
+   * - ``LoadMaintPremParam<N>``
+     - Linear parameters of the premium-based maintenance loading,
+       with ``N`` = 1, 2 (see
+       :func:`~annuallife.TradLife_A.PolicyAttrs.load_maint_prem`).
+   * - ``SurrChargeParam<N>``
+     - Parameters of the initial surrender charge, with ``N`` = 1, 2
+       (see :func:`~annuallife.TradLife_A.PolicyAttrs.init_surr_charge`).
+   * - ``MortTable<Basis>``
+     - Mortality table ID (column of ``MortalityTables``) for
+       ``<Basis>``, where ``Basis`` is ``Prem`` (premium basis) or
+       ``Val`` (valuation basis).
+   * - ``IntRate<Basis>``
+     - Interest rate for ``<Basis>``; ``Basis`` as above.
+   * - ``LapseRate<Basis>``
+     - Annual lapse rate for ``<Basis>``; ``Basis`` as above.
    * - ``Hsx``, ``Tsx``, ``Hax``, ``Tax``
      - Optional commutation-function parameters for products that need
        them (left blank for products that do not).
 
-``AssumptionTable``
-^^^^^^^^^^^^^^^^^^^
+Assumption parameters
+^^^^^^^^^^^^^^^^^^^^^
 
-Per-product assumption set. Read column-by-column by
+Named range: ``AssumptionTable``
+
+Table of actuarial assumption parameters — mortality and lapse
+references, commission rates, expense factors, and tax/inflation
+rates — keyed by ``Product`` / ``PolType`` / ``Gen``. Read
+column-by-column by
 :func:`~annuallife.TradLife_A.InputData.assumption`, which returns each
-column as a Series keyed by ``Product`` / ``PolType`` / ``Gen``. Rows
-are sparse: a product-level row sets the defaults, and more specific
-(``PolType`` / ``Gen``) rows override individual columns.
+column as a Series. Rows are sparse: a product-level row sets the
+defaults, and more specific (``PolType`` / ``Gen``) rows override
+individual columns.
 
 .. list-table::
    :header-rows: 1
@@ -306,7 +318,7 @@ are sparse: a product-level row sets the defaults, and more specific
    * - Column
      - Description
    * - ``Product``, ``PolType``, ``Gen``
-     - Lookup levels for the assumption set.
+     - Lookup keys for the assumption set.
    * - ``BaseMort``
      - Base mortality table ID (column of ``MortalityTables``).
    * - ``MortFactor``
@@ -325,21 +337,26 @@ are sparse: a product-level row sets the defaults, and more specific
        premium.
    * - ``CommRenTerm``
      - Number of renewal years over which ``CommRenPrem`` applies.
-   * - ``ExpsAcqSA``, ``ExpsAcqAnnPrem``, ``ExpsAcqPol``
-     - Acquisition expense factors per sum assured, per annualised
-       premium and per policy.
-   * - ``ExpsMaintSA``, ``ExpsMaintPrem``, ``ExpsMaintPol``
-     - Maintenance expense factors per sum assured, per premium and per
-       policy.
+   * - ``ExpsAcq<Unit>``
+     - Acquisition expense factor per ``<Unit>``, where ``Unit`` is
+       ``SA`` (per sum assured), ``AnnPrem`` (per annualised premium),
+       or ``Pol`` (per policy).
+   * - ``ExpsMaint<Unit>``
+     - Maintenance expense factor per ``<Unit>``, where ``Unit`` is
+       ``SA`` (per sum assured), ``Prem`` (per premium), or ``Pol``
+       (per policy).
    * - ``InflRate``
      - Expense inflation rate applied to maintenance expenses.
    * - ``CnsmpTax``
      - Consumption-tax rate applied to expenses.
 
-``AsmpByDuration``
-^^^^^^^^^^^^^^^^^^
+Assumptions by duration
+^^^^^^^^^^^^^^^^^^^^^^^
 
-Duration-indexed assumption tables. Read by
+Named range: ``AsmpByDuration``
+
+Duration-indexed tables of mortality factors, morbidity rates, and
+lapse rates. Read by
 :func:`~annuallife.TradLife_A.InputData.assumption_tables`, which
 returns a ``DataFrame`` indexed by ``Year``. Columns of this range are
 referenced by name from ``AssumptionTable`` (e.g. ``MortFactor`` and
@@ -353,18 +370,20 @@ referenced by name from ``AssumptionTable`` (e.g. ``MortFactor`` and
      - Description
    * - ``Year``
      - Policy duration in years; becomes the DataFrame index.
-   * - ``MortAsmp1``, ``MortAsmp2``
-     - Duration-based mortality-factor tables selectable from
-       ``MortFactor`` in ``AssumptionTable``.
-   * - ``Morb1`` ... ``Morb5``
-     - Duration-based morbidity-rate tables (defined for future use;
-       not consumed by the current projection Cells).
-   * - ``LapseRate1``
-     - Duration-based lapse-rate table selectable from ``Surrender`` in
-       ``AssumptionTable``.
+   * - ``MortAsmp<N>``
+     - Duration-based mortality-factor tables (``N`` = 1, 2) selectable
+       from ``MortFactor`` in ``AssumptionTable``.
+   * - ``Morb<N>``
+     - Duration-based morbidity-rate tables (``N`` = 1..5; defined for
+       future use, not consumed by the current projection Cells).
+   * - ``LapseRate<N>``
+     - Duration-based lapse-rate tables (``N`` = 1) selectable from
+       ``Surrender`` in ``AssumptionTable``.
 
-``MortalityTables``
-^^^^^^^^^^^^^^^^^^^
+Mortality tables
+^^^^^^^^^^^^^^^^
+
+Named range: ``MortalityTables``
 
 Mortality rates by attained age and (mortality table ID, sex), with a
 two-row header (``MortTable`` over ``Sex``). Read by
@@ -389,12 +408,13 @@ returns a ``DataFrame`` indexed by age with a column ``MultiIndex`` of
    * - Cell value
      - Annual mortality rate for the (table, sex, age).
 
-``Scenarios``
-^^^^^^^^^^^^^
+Economic scenarios
+^^^^^^^^^^^^^^^^^^
 
-Economic scenarios. Read by
-:func:`~annuallife.TradLife_A.InputData.scenarios`, which returns a
-``DataFrame`` indexed by ``(ScenID, Year)``.
+Named range: ``Scenarios``
+
+Read by :func:`~annuallife.TradLife_A.InputData.scenarios`, which
+returns a ``DataFrame`` indexed by ``(ScenID, Year)``.
 
 .. list-table::
    :header-rows: 1
@@ -410,11 +430,13 @@ Economic scenarios. Read by
    * - ``IntRate``
      - Annual interest rate at time ``Year`` under scenario ``ScenID``.
 
-``LargePolDiscount``
-^^^^^^^^^^^^^^^^^^^^
+Large-policy premium discount
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Two-column named range mapping sum-assured bands to a premium discount.
-Read as a :obj:`dict` and turned into a per-policy ``Series`` by
+Named range: ``LargePolDiscount``
+
+Two-column range mapping sum-assured bands to a premium discount. Read
+as a :obj:`dict` and turned into a per-policy ``Series`` by
 :func:`~annuallife.TradLife_A.InputData.discount_rate`, which uses the
 keys as left-closed band boundaries.
 
@@ -431,11 +453,13 @@ keys as left-closed band boundaries.
      - Premium discount applied to policies whose ``SumAssured`` falls
        in that band.
 
-``PremiumWaiverCost``
-^^^^^^^^^^^^^^^^^^^^^
+Premium-waiver cost
+^^^^^^^^^^^^^^^^^^^
 
-Two-column named range mapping policy-term bands to a premium-waiver
-loading. Read as a :obj:`dict` by
+Named range: ``PremiumWaiverCost``
+
+Two-column range mapping policy-term bands to a premium-waiver loading.
+Read as a :obj:`dict` by
 :func:`~annuallife.TradLife_A.InputData.prem_waiver_cost`.
 
 .. list-table::
@@ -450,12 +474,13 @@ loading. Read as a :obj:`dict` by
    * - Second column
      - Premium-waiver cost loading for that band.
 
-``ConstParams``
-^^^^^^^^^^^^^^^
+Constant parameters
+^^^^^^^^^^^^^^^^^^^
 
-Two-column named range of scalar parameters used across the model.
-Read as a :obj:`dict` by
-:func:`~annuallife.TradLife_A.InputData.const_params`.
+Named range: ``ConstParams``
+
+Two-column range of scalar parameters used across the model. Read as a
+:obj:`dict` by :func:`~annuallife.TradLife_A.InputData.const_params`.
 
 .. list-table::
    :header-rows: 1

--- a/lifelib/libraries/annuallife/TradLife_A/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/__init__.py
@@ -194,43 +194,279 @@ located next to the *TradLife_A* model directory inside the library
 folder. The default file name is set by the
 :attr:`~annuallife.TradLife_A.InputData.input_file_name` reference.
 
-The workbook defines the following named ranges, picked up through cells
-in :mod:`~annuallife.TradLife_A.InputData`:
+The workbook defines the named ranges described below. Each one is read
+through a Cells in :mod:`~annuallife.TradLife_A.InputData`.
+
+.. seealso::
+
+   :mod:`~annuallife.TradLife_A.InputData` for the Cells that load these
+   named ranges and the helpers that turn them into :mod:`pandas`
+   objects.
+
+``PolicyData``
+^^^^^^^^^^^^^^
+
+Per-policy attributes for the model points the projection runs over.
+One row per policy, loaded by
+:func:`~annuallife.TradLife_A.InputData.policy_data` and indexed by
+the ``Policy`` column.
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 40 35
+   :widths: 25 75
 
-   * - External named range
-     - Cells
-     - Purpose
-   * - ``PolicyData``
-     - :func:`~annuallife.TradLife_A.InputData.policy_data`
-     - Per-policy attributes for model points
-   * - ``ProductSpecTable``
-     - :func:`~annuallife.TradLife_A.InputData.product_spec`
-     - Per-product loading and rate tables
-   * - ``AssumptionTable``
-     - :func:`~annuallife.TradLife_A.InputData.assumption`
-     - Lookup table of assumption keys
-   * - ``AsmpByDuration``
-     - :func:`~annuallife.TradLife_A.InputData.assumption_tables`
-     - Duration-based mortality / lapse tables
-   * - ``MortalityTables``
-     - :func:`~annuallife.TradLife_A.InputData.mortality_tables`
-     - Mortality tables keyed by Sex / Table
-   * - ``Scenarios``
-     - :func:`~annuallife.TradLife_A.InputData.scenarios`
-     - Scenario interest-rate paths
-   * - ``LargePolDiscount``
-     - :func:`~annuallife.TradLife_A.InputData.discount_rate`
-     - Premium discount by sum-assured band
-   * - ``PremiumWaiverCost``
-     - :func:`~annuallife.TradLife_A.InputData.prem_waiver_cost`
-     - Premium-waiver cost lookup
-   * - ``ConstParams``
-     - :func:`~annuallife.TradLife_A.InputData.const_params`
-     - Scalar parameters used across the model
+   * - Column
+     - Description
+   * - ``Policy``
+     - Policy ID. Becomes the DataFrame index.
+   * - ``Product``
+     - Product code (``TERM``, ``WL`` or ``ENDW``); a value of the
+       :mod:`~annuallife.TradLife_A.Enums.ProductID` enum.
+   * - ``PolType``
+     - Policy-type sub-category within the product.
+   * - ``Gen``
+     - Product generation / cohort identifier.
+   * - ``Channel``
+     - Distribution channel.
+   * - ``Duration``
+     - Elapsed policy duration in years at the projection start.
+   * - ``Sex``
+     - Insured sex (``M`` or ``F``); a value of the
+       :mod:`~annuallife.TradLife_A.Enums.SexID` enum.
+   * - ``IssueAge``
+     - Age at policy issue.
+   * - ``PaymentMode``
+     - Premium payment mode (number of payments per year).
+   * - ``PremFreq``
+     - Premium-paying period in years.
+   * - ``PolicyTerm``
+     - Term of the policy in years.
+   * - ``MaxPolicyTerm``
+     - Maximum policy term used to cap term-dependent items.
+   * - ``PolicyCount``
+     - Number of policies represented by the model point.
+   * - ``SumAssured``
+     - Sum assured per policy.
+
+``ProductSpecTable``
+^^^^^^^^^^^^^^^^^^^^
+
+Per-product specification table holding loading parameters, surrender
+charges and the mortality, interest and lapse references used on the
+premium and valuation bases. Read column-by-column by
+:func:`~annuallife.TradLife_A.InputData.product_spec`, which returns
+each column as a Series keyed by ``Product`` / ``PolType`` / ``Gen``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Column
+     - Description
+   * - ``Product``, ``PolType``, ``Gen``
+     - Lookup levels. ``Product`` matches ``Product`` in ``PolicyData``;
+       ``PolType`` and ``Gen`` are optional refinements and may be left
+       blank for product-wide entries.
+   * - ``LoadAcqSAParam1``, ``LoadAcqSAParam2``
+     - Linear parameters of the sum-assured-based acquisition loading
+       (see :func:`~annuallife.TradLife_A.PolicyAttrs.load_acq_sa`).
+   * - ``LoadMaintSA``, ``LoadMaintSA2``
+     - Sum-assured-based maintenance loadings during and after the
+       premium-paying period.
+   * - ``LoadMaintPremParam1``, ``LoadMaintPremParam2``
+     - Linear parameters of the premium-based maintenance loading
+       (see :func:`~annuallife.TradLife_A.PolicyAttrs.load_maint_prem`).
+   * - ``SurrChargeParam1``, ``SurrChargeParam2``
+     - Parameters of the initial surrender charge (see
+       :func:`~annuallife.TradLife_A.PolicyAttrs.init_surr_charge`).
+   * - ``MortTablePrem``, ``MortTableVal``
+     - Mortality table IDs (columns of ``MortalityTables``) used on the
+       premium and valuation bases.
+   * - ``IntRatePrem``, ``IntRateVal``
+     - Interest rates used on the premium and valuation bases.
+   * - ``LapseRatePrem``, ``LapseRateVal``
+     - Annual lapse rates used on the premium and valuation bases.
+   * - ``Hsx``, ``Tsx``, ``Hax``, ``Tax``
+     - Optional commutation-function parameters for products that need
+       them (left blank for products that do not).
+
+``AssumptionTable``
+^^^^^^^^^^^^^^^^^^^
+
+Per-product assumption set. Read column-by-column by
+:func:`~annuallife.TradLife_A.InputData.assumption`, which returns each
+column as a Series keyed by ``Product`` / ``PolType`` / ``Gen``. Rows
+are sparse: a product-level row sets the defaults, and more specific
+(``PolType`` / ``Gen``) rows override individual columns.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Column
+     - Description
+   * - ``Product``, ``PolType``, ``Gen``
+     - Lookup levels for the assumption set.
+   * - ``BaseMort``
+     - Base mortality table ID (column of ``MortalityTables``).
+   * - ``MortFactor``
+     - Name of the ``AsmpByDuration`` column used as a duration-based
+       mortality factor; resolved via
+       :mod:`~annuallife.TradLife_A.Assumptions.AsmpID`.
+   * - ``Surrender``
+     - Name of the ``AsmpByDuration`` column used as the duration-based
+       lapse rate.
+   * - ``Renewal``
+     - Renewal-premium retention assumption.
+   * - ``InvstRet``
+     - Assumed investment return.
+   * - ``CommInitPrem``, ``CommRenPrem``
+     - First-year and renewal-year commission rates as a fraction of
+       premium.
+   * - ``CommRenTerm``
+     - Number of renewal years over which ``CommRenPrem`` applies.
+   * - ``ExpsAcqSA``, ``ExpsAcqAnnPrem``, ``ExpsAcqPol``
+     - Acquisition expense factors per sum assured, per annualised
+       premium and per policy.
+   * - ``ExpsMaintSA``, ``ExpsMaintPrem``, ``ExpsMaintPol``
+     - Maintenance expense factors per sum assured, per premium and per
+       policy.
+   * - ``InflRate``
+     - Expense inflation rate applied to maintenance expenses.
+   * - ``CnsmpTax``
+     - Consumption-tax rate applied to expenses.
+
+``AsmpByDuration``
+^^^^^^^^^^^^^^^^^^
+
+Duration-indexed assumption tables. Read by
+:func:`~annuallife.TradLife_A.InputData.assumption_tables`, which
+returns a ``DataFrame`` indexed by ``Year``. Columns of this range are
+referenced by name from ``AssumptionTable`` (e.g. ``MortFactor`` and
+``Surrender``).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Column
+     - Description
+   * - ``Year``
+     - Policy duration in years; becomes the DataFrame index.
+   * - ``MortAsmp1``, ``MortAsmp2``
+     - Duration-based mortality-factor tables selectable from
+       ``MortFactor`` in ``AssumptionTable``.
+   * - ``Morb1`` ... ``Morb5``
+     - Duration-based morbidity-rate tables (defined for future use;
+       not consumed by the current projection Cells).
+   * - ``LapseRate1``
+     - Duration-based lapse-rate table selectable from ``Surrender`` in
+       ``AssumptionTable``.
+
+``MortalityTables``
+^^^^^^^^^^^^^^^^^^^
+
+Mortality rates by attained age and (mortality table ID, sex), with a
+two-row header (``MortTable`` over ``Sex``). Read by
+:func:`~annuallife.TradLife_A.InputData.mortality_tables`, which
+returns a ``DataFrame`` indexed by age with a column ``MultiIndex`` of
+``(MortTable, Sex)``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Column
+     - Description
+   * - ``Age`` (row index)
+     - Attained age in years.
+   * - ``MortTable`` (top header)
+     - Mortality table ID (integer); referenced by ``BaseMort`` in
+       ``AssumptionTable`` and by ``MortTablePrem`` / ``MortTableVal``
+       in ``ProductSpecTable``.
+   * - ``Sex`` (sub-header)
+     - Sex code (``M`` or ``F``) within each table.
+   * - Cell value
+     - Annual mortality rate for the (table, sex, age).
+
+``Scenarios``
+^^^^^^^^^^^^^
+
+Economic scenarios. Read by
+:func:`~annuallife.TradLife_A.InputData.scenarios`, which returns a
+``DataFrame`` indexed by ``(ScenID, Year)``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Column
+     - Description
+   * - ``ScenID``
+     - Scenario ID. Selected through the ``scen_id`` parameter of
+       :mod:`~annuallife.TradLife_A.Economic`.
+   * - ``Year``
+     - Time index (year) within the scenario.
+   * - ``IntRate``
+     - Annual interest rate at time ``Year`` under scenario ``ScenID``.
+
+``LargePolDiscount``
+^^^^^^^^^^^^^^^^^^^^
+
+Two-column named range mapping sum-assured bands to a premium discount.
+Read as a :obj:`dict` and turned into a per-policy ``Series`` by
+:func:`~annuallife.TradLife_A.InputData.discount_rate`, which uses the
+keys as left-closed band boundaries.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Column
+     - Description
+   * - First column
+     - Upper bound of the sum-assured band. The last row may be left
+       blank, in which case the final band has no upper bound.
+   * - Second column
+     - Premium discount applied to policies whose ``SumAssured`` falls
+       in that band.
+
+``PremiumWaiverCost``
+^^^^^^^^^^^^^^^^^^^^^
+
+Two-column named range mapping policy-term bands to a premium-waiver
+loading. Read as a :obj:`dict` by
+:func:`~annuallife.TradLife_A.InputData.prem_waiver_cost`.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Column
+     - Description
+   * - First column
+     - Upper bound of the policy-term band. The last row may be left
+       blank, in which case the final band has no upper bound.
+   * - Second column
+     - Premium-waiver cost loading for that band.
+
+``ConstParams``
+^^^^^^^^^^^^^^^
+
+Two-column named range of scalar parameters used across the model.
+Read as a :obj:`dict` by
+:func:`~annuallife.TradLife_A.InputData.const_params`.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Column
+     - Description
+   * - First column
+     - Parameter name (e.g. ``InflRate``, ``CnsmpTax``).
+   * - Second column
+     - Parameter value.
 
 .. _tradlife_a-basic-usage:
 


### PR DESCRIPTION
## Summary

Three doc-only commits for `TradLife_A` covering minor docstring fixes, the
**Input File** section in the top-level module docstring, and a couple of
in-Space docstring tweaks.

## What changed

- **`ef35c71` — minor wording and term casing fixes.**
  `PolicyAttrs/__init__.py`: "per-policy data" → "product specs" (more
  accurate for what `InputData` provides). `Utilities/__init__.py`:
  "uncached cell" → "uncached Cells" in two docstrings, matching the
  modelx term-casing convention.
- **`2928590` — expand Input File section with per-range subsections.**
  Replaced the single named-range list-table with one subsection per
  range, each carrying a column-level table describing the schema, and
  added a section-level `.. seealso::` pointing at the `InputData` Space.
- **`d7fbba1` — rename subsections and collapse parameter families.**
  Subsections now have descriptive titles (e.g. *Model point data*) with
  the underlying named range shown on a "Named range:" line beneath the
  heading. Numbered / `Prem`/`Val` / unit-suffixed column families are
  collapsed into `…<N>` / `…<Basis>` / `…<Unit>` forms with the
  placeholder explained inline. "Lookup levels" renamed to "Lookup keys".
  The *Assumption parameters* lead-in is rewritten to describe what the
  table actually holds, and *Assumptions by duration* now names the kinds
  of rates it contains.

## Why

Make the `TradLife_A` input file easier to navigate from the rendered
docs — the previous single list-table mapped named ranges to loader
Cells but didn't describe what was in each range. Reviewers asking
"what's in `ProductSpecTable`?" had to open the workbook to find out.

## Test plan

- [x] `sphinx -b html` builds cleanly (no new warnings; 15 pre-existing
  warnings unchanged).
- [x] All 9 Input File subsections render as `<h3>` with their "Named
  range:" line, column tables and `<N>` / `<Basis>` / `<Unit>` tokens
  intact in the generated HTML.
- [x] No code changes; runtime behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)