### PR TITLE
DOC: TradLife_A: reorder sub docs and consolidate inheritance diagram

### DIFF
--- a/doc/source/libraries/annuallife/TradLife_A.rst
+++ b/doc/source/libraries/annuallife/TradLife_A.rst
@@ -8,12 +8,12 @@ The **TradLife_A** Model
    :maxdepth: 1
 
    InputData
+   PolicyAttrs
+   Assumptions
+   CommTable
    Economic
    BaseProj
    PV
    Projection
-   Assumptions
-   PolicyAttrs
    Utilities
-   CommTable
    Enums

--- a/lifelib/libraries/annuallife/TradLife_A/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/__init__.py
@@ -35,14 +35,14 @@ proceeds as follows.
 .. mermaid::
 
     graph LR
-        Projection --> Economic
-        Projection --> Assumptions
         Projection --> PolicyAttrs
+        Projection --> Assumptions
         Projection --> CommTable
-        Economic --> InputData
-        Assumptions --> InputData
+        Projection --> Economic
         PolicyAttrs --> InputData
+        Assumptions --> InputData
         CommTable --> InputData
+        Economic --> InputData
 
 * The data is read into the model from the input file in
   :mod:`~annuallife.TradLife_A.InputData`, and held there as
@@ -135,14 +135,6 @@ Inheritance
 :mod:`~annuallife.TradLife_A.BaseProj` and
 :mod:`~annuallife.TradLife_A.PV`, so projection cells and their
 present-value counterparts share the same parameter scope.
-
-.. mermaid::
-
-    %%{init: {"class": {"hideEmptyMembersBox": true}}}%%
-    classDiagram
-        BaseProj <|-- Projection
-        PV <|-- Projection
-
 :mod:`~annuallife.TradLife_A.Assumptions` and
 :mod:`~annuallife.TradLife_A.PolicyAttrs` inherit from
 :mod:`~annuallife.TradLife_A.Utilities`, which contributes the
@@ -152,6 +144,8 @@ present-value counterparts share the same parameter scope.
 
     %%{init: {"class": {"hideEmptyMembersBox": true}}}%%
     classDiagram
+        BaseProj <|-- Projection
+        PV <|-- Projection
         Utilities <|-- Assumptions
         Utilities <|-- PolicyAttrs
 


### PR DESCRIPTION
## Summary

- Reorder the `TradLife_A` toctree so `PolicyAttrs`, `Assumptions` and `CommTable` follow `InputData`, grouping the data-feed spaces next to where their data is loaded before the projection-side spaces.
- Mirror the new ordering in the *Computation flow* mermaid diagram in `TradLife_A`'s docstring so `Projection -> {PolicyAttrs, Assumptions, CommTable, Economic}` and the `... --> InputData` edges follow the same sequence.
- Merge the two mermaid `classDiagram` blocks in the *Inheritance* section into one — the previous standalone diagrams rendered too large for what they convey. The single diagram now shows `BaseProj`/`PV` -> `Projection` and `Utilities` -> `Assumptions`/`PolicyAttrs` together, and the surrounding prose is consolidated into one paragraph that precedes it.

No code or behavior changes — documentation only.

## Test plan

- [ ] Build the Sphinx docs and confirm the `TradLife_A` page renders with the new toctree order.
- [ ] Confirm the *Computation flow* mermaid diagram renders with the reordered edges.
- [ ] Confirm the *Inheritance* section now shows a single merged class diagram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)