### PR TITLE
TradLife_A.CommTable: reference InputData Space instead of the cells directly

### DIFF
--- a/lifelib/libraries/annuallife/TradLife_A/CommTable/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/CommTable/__init__.py
@@ -38,7 +38,8 @@ Attributes:
 .. rubric:: References
 
 Attributes:
-    mortality_tables: Alias for
+    input_data: Alias for :mod:`~annuallife.TradLife_A.InputData`. The
+        mortality tables are read through
         :func:`~annuallife.TradLife_A.InputData.mortality_tables`.
 
 Example:
@@ -274,9 +275,10 @@ def mortality_rates():
     matching this Space's :attr:`Table` and :attr:`Sex` parameters and
     returns the resulting per-age mortality rate Series.
     """
-    pos = list((t, getattr(SexID, s)) for t, s in mortality_tables().columns).index((Table, Sex))
+    mortality_tables = input_data.mortality_tables()
+    pos = list((t, getattr(SexID, s)) for t, s in mortality_tables.columns).index((Table, Sex))
 
-    return mortality_tables().iloc[:, pos]
+    return mortality_tables.iloc[:, pos]
 
 
 # ---------------------------------------------------------------------------
@@ -288,4 +290,4 @@ IntRate = 0.01
 
 TableID = 1
 
-mortality_tables = ("Interface", ("..", "InputData", "mortality_tables"), "absolute")
+input_data = ("Interface", ("..", "InputData"), "auto")

--- a/lifelib/libraries/annuallife/TradLife_A/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/__init__.py
@@ -161,12 +161,12 @@ spaces resolve a number of References to other spaces:
 * ``comm_table`` -> :mod:`~annuallife.TradLife_A.CommTable`
 
 :mod:`~annuallife.TradLife_A.Economic`,
-:mod:`~annuallife.TradLife_A.Assumptions` and
-:mod:`~annuallife.TradLife_A.PolicyAttrs` each reference the
-:mod:`~annuallife.TradLife_A.InputData` space as ``input_data``, while
-:mod:`~annuallife.TradLife_A.CommTable` references the
-:func:`~annuallife.TradLife_A.InputData.mortality_tables` cells defined
-in :mod:`~annuallife.TradLife_A.InputData` as ``mortality_tables``.
+:mod:`~annuallife.TradLife_A.Assumptions`,
+:mod:`~annuallife.TradLife_A.PolicyAttrs` and
+:mod:`~annuallife.TradLife_A.CommTable` each reference the
+:mod:`~annuallife.TradLife_A.InputData` space as ``input_data``.
+:mod:`~annuallife.TradLife_A.CommTable` reads its mortality tables
+through :func:`~annuallife.TradLife_A.InputData.mortality_tables`.
 
 .. mermaid::
 
@@ -178,7 +178,7 @@ in :mod:`~annuallife.TradLife_A.InputData` as ``mortality_tables``.
         Economic -- input_data --> InputData
         Assumptions -- input_data --> InputData
         PolicyAttrs -- input_data --> InputData
-        CommTable -- mortality_tables --> InputData
+        CommTable -- input_data --> InputData
 
 Input File
 ----------


### PR DESCRIPTION
@
## What

In `annuallife.TradLife_A.CommTable`, replace the direct Interface reference to the `InputData.mortality_tables` Cells with a reference to the whole `InputData` Space, named `input_data`, and access the mortality tables through `input_data.mortality_tables()`.

## Why

The sibling Spaces — `Economic`, `Assumptions` and `PolicyAttrs` — all reference `InputData` as `input_data` (`auto`). `CommTable` was the odd one out, holding an `absolute` Interface reference straight to the `mortality_tables` Cells. Aligning it with the others makes the cross-Space reference convention consistent across the model.

## Changes

**`TradLife_A/CommTable/__init__.py`**
- Reference: `mortality_tables = ("Interface", ("..", "InputData", "mortality_tables"), "absolute")` → `input_data = ("Interface", ("..", "InputData"), "auto")`
- `mortality_rates()` now reads the table via `input_data.mortality_tables()`
- Updated the module docstring References section to document `input_data`

**`TradLife_A/__init__.py`**
- Updated the Space-relationship prose: `CommTable` now references `InputData` as `input_data` like the other Spaces
- Updated the mermaid diagram edge to `CommTable -- input_data --> InputData`

## Verification

Loaded the model with `modelx` (py313 env) and reproduced the CommTable docstring example exactly:

```
m.CommTable[SexID.M, 0.03, 1].AnnDuenx(40, 10)  ->  8.725179890621531
```

## Note for reviewers

This is applied to the canonical `TradLife_A` model only. The generated `TradLife_A_mx30` variant still carries the old reference and would need to be regenerated separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@