### PR TITLE
Fix inflation factor calculation in TradLife models

### DIFF
--- a/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
@@ -935,7 +935,7 @@ def inflation_factor(t):
     if t == 0:
         return 1
     else:
-        return inflation_factor(t-1) / (1 + asmp.inflation_rate())
+        return inflation_factor(t-1) * (1 + asmp.inflation_rate())
 
 
 def disc_rate_mth(t):

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/BaseProj/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/BaseProj/__init__.py
@@ -820,7 +820,7 @@ def inflation_factor(t):
     if t == 0:
         return 1
     else:
-        return inflation_factor(t-1) / (1 + asmp.inflation_rate())
+        return inflation_factor(t-1) * (1 + asmp.inflation_rate())
 
 
 def disc_rate_mth(t):


### PR DESCRIPTION
## Summary
Fixed the inflation factor calculation in the TradLife_A and TradLife_A_mx30 models by correcting the mathematical operation from division to multiplication.

## Key Changes
- Changed `inflation_factor(t-1) / (1 + asmp.inflation_rate())` to `inflation_factor(t-1) * (1 + asmp.inflation_rate())` in both models
- Applied fix to:
  - `lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py`
  - `lifelib/libraries/annuallife/TradLife_A_mx30/BaseProj/__init__.py`

## Implementation Details
The inflation factor should compound forward in time by multiplying by (1 + inflation_rate), not dividing. The previous implementation was incorrectly deflating the factor instead of inflating it. This correction ensures that the inflation factor properly accumulates over time periods, which is essential for accurate financial projections in the actuarial models.

https://claude.ai/code/session_01HqWCNmCb1f76Exvpu3yVnx