### PR TITLE
ENH: TradLife_A_EX1: add risk_life(t, risk) Solvency II life SCR cell

### DIFF
--- a/lifelib/libraries/annuallife/TradLife_A_EX1/Projection/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/Projection/__init__.py
@@ -18,6 +18,16 @@ The projection cells are inherited from
 :mod:`~annuallife.TradLife_A.BaseProj`, and the present values of those
 cashflow items are inherited from :mod:`~annuallife.TradLife_A.PV`.
 
+.. rubric:: Cells
+
+In addition to the inherited cashflow and present-value Cells, this
+Space defines :func:`risk_life`, the Solvency II life underwriting
+capital requirement for each life sub-risk. It is the loss in the value
+of in-force, i.e. the baseline less the stressed present value of
+:func:`~annuallife.TradLife_A.PV.pv_net_cf`, taken from the inner
+projection :mod:`~annuallife.TradLife_A.Projection.InnerProj`. It
+mirrors ``SCR_life.Life`` in the ``solvency2`` library.
+
 Parameters and References
 -------------------------
 
@@ -63,3 +73,61 @@ _spaces = [
     "InnerProj"
 ]
 
+# ---------------------------------------------------------------------------
+# Cells
+
+def risk_life(t, risk):
+    r"""Life underwriting capital requirement for ``risk`` at valuation time ``t``.
+
+    The capital requirement for a life sub-risk is the loss in the value
+    of in-force business caused by applying the prescribed Solvency II
+    life stress: the baseline present value of net cashflows less the
+    stressed present value, floored at zero.
+
+    .. math::
+
+        \mathrm{risk\_life}(t, risk) =
+        \max\left(\mathrm{pv\_net\_cf}_{base}(t)
+        - \mathrm{pv\_net\_cf}_{risk}(t),\; 0\right)
+
+    Both present values are taken at the valuation time ``t`` from the
+    inner projection :mod:`~annuallife.TradLife_A.Projection.InnerProj`,
+    which is anchored at ``t``. ``InnerProj[t]`` is the unstressed
+    (baseline) run, while ``InnerProj[t, risk]`` applies the life shock
+    selected by ``risk``. For the lapse risk the requirement is the worst
+    loss across the three prescribed lapse shocks (up, down and mass).
+
+    This mirrors ``SCR_life.Life`` (and, for the lapse shocks,
+    ``SCR_life.LapseRisk``) in the ``solvency2`` library, with
+    :func:`~annuallife.TradLife_A.PV.pv_net_cf` standing in for the net
+    asset value.
+
+    Args:
+        t: Valuation time at which the inner projection is anchored.
+        risk: A :class:`~annuallife.TradLife_A.Enums.LifeRiskID.LifeRiskID`
+            value selecting the life sub-risk (e.g. ``MORT``, ``LONGV``,
+            ``LAPSE``, ``EXPS``).
+
+    .. seealso::
+
+        * :func:`~annuallife.TradLife_A.PV.pv_net_cf`
+        * :mod:`~annuallife.TradLife_A.Projection.InnerProj`
+    """
+    base_pv = InnerProj[t].pv_net_cf(t)
+
+    if risk == LifeRiskID.LAPSE:
+        return max(
+            max(base_pv - InnerProj[t, risk, shock].pv_net_cf(t), 0)
+            for shock in (LapseShockID.UP,
+                          LapseShockID.DOWN,
+                          LapseShockID.MASS))
+    else:
+        return max(base_pv - InnerProj[t, risk].pv_net_cf(t), 0)
+
+
+# ---------------------------------------------------------------------------
+# References
+
+LifeRiskID = ("Interface", ("..", "Enums", "LifeRiskID"), "auto")
+
+LapseShockID = ("Interface", ("..", "Enums", "LapseShockID"), "auto")

--- a/lifelib/tests/libraries/test_tradlife_a_ex1.py
+++ b/lifelib/tests/libraries/test_tradlife_a_ex1.py
@@ -1,0 +1,120 @@
+"""Tests for ``risk_life`` in the ``TradLife_A_EX1`` Solvency II model.
+
+``Projection.risk_life(t, risk)`` is the life underwriting capital
+requirement for each life sub-risk: the baseline less the stressed
+present value of ``pv_net_cf`` taken from the inner projection
+``InnerProj``, floored at zero, with the lapse risk taking the worst of
+the up/down/mass shocks. This mirrors ``SCR_life.Life`` / ``LapseRisk``
+in the ``solvency2`` library.
+
+Because ``TradLife_A_EX1`` reads ``input.xlsx`` from its parent directory
+(``_model.path.parent / input_file_name``), we copy both the model and
+the workbook into a temporary directory so the model loads from a
+self-contained location during the tests.
+"""
+import math
+import pathlib
+import shutil
+import tempfile
+import tokenize
+
+import pytest
+
+modelx = pytest.importorskip("modelx")
+
+# modelx 0.28+ tightened DocstringParser to require the docstring at
+# line 1, but lifelib's serialized models prefix it with a four-line
+# "# modelx: pseudo-python" comment header. Relax the check so the
+# model files load.
+try:
+    from modelx.serialize import serializer_6 as _s6
+
+    @classmethod
+    def _docstring_condition(cls, stmt):
+        return (
+            stmt.section == "DEFAULT"
+            and len(stmt) == 1
+            and stmt[0].type == tokenize.STRING
+        )
+
+    _s6.DocstringParser.condition = _docstring_condition
+except (ImportError, AttributeError):
+    pass
+
+
+HERE = pathlib.Path(__file__).resolve()
+LIBRARIES = HERE.parents[2] / "libraries"
+TRADLIFE_A_EX1_MODEL = LIBRARIES / "annuallife" / "TradLife_A_EX1"
+TRADLIFE_A_EX1_INPUT = LIBRARIES / "annuallife" / "input.xlsx"
+
+IDXS = [0, 100, 200]
+
+# Life sub-risks for which InnerProj applies a stress.
+SHOCKED_RISKS = ["MORT", "LONGV", "EXPS"]
+# Life sub-risks not modelled by InnerProj (no stress -> zero requirement).
+UNSHOCKED_RISKS = ["DISAB", "REV", "CAT"]
+
+
+@pytest.fixture(scope="module")
+def ex1_model():
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+        tmp = pathlib.Path(tmp)
+        shutil.copytree(TRADLIFE_A_EX1_MODEL, tmp / "TradLife_A_EX1")
+        shutil.copy(TRADLIFE_A_EX1_INPUT, tmp / "input.xlsx")
+        model = modelx.read_model(tmp / "TradLife_A_EX1")
+        try:
+            yield model
+        finally:
+            model.close()
+
+
+@pytest.mark.parametrize("idx", IDXS)
+@pytest.mark.parametrize("risk_name", SHOCKED_RISKS + UNSHOCKED_RISKS + ["LAPSE"])
+def test_risk_life_is_nonnegative(ex1_model, idx, risk_name):
+    """The max(., 0) floor makes every requirement non-negative."""
+    proj = ex1_model.Projection[idx]
+    risk = getattr(ex1_model.Enums.LifeRiskID, risk_name)
+    assert proj.risk_life(0, risk) >= 0
+
+
+@pytest.mark.parametrize("idx", IDXS)
+@pytest.mark.parametrize("risk_name", SHOCKED_RISKS)
+def test_risk_life_equals_floored_difference(ex1_model, idx, risk_name):
+    """For a non-lapse risk: max(baseline_pv - stressed_pv, 0)."""
+    proj = ex1_model.Projection[idx]
+    risk = getattr(ex1_model.Enums.LifeRiskID, risk_name)
+    base_pv = proj.InnerProj[0].pv_net_cf(0)
+    stressed_pv = proj.InnerProj[0, risk].pv_net_cf(0)
+    expected = max(base_pv - stressed_pv, 0)
+    assert math.isclose(
+        proj.risk_life(0, risk), expected, rel_tol=1e-9, abs_tol=1e-9)
+
+
+@pytest.mark.parametrize("idx", IDXS)
+@pytest.mark.parametrize("risk_name", UNSHOCKED_RISKS)
+def test_risk_life_zero_for_unshocked_risks(ex1_model, idx, risk_name):
+    """Risks InnerProj does not model leave pv_net_cf unchanged -> 0."""
+    proj = ex1_model.Projection[idx]
+    risk = getattr(ex1_model.Enums.LifeRiskID, risk_name)
+    assert proj.risk_life(0, risk) == 0
+
+
+@pytest.mark.parametrize("idx", IDXS)
+def test_risk_life_lapse_is_worst_shock(ex1_model, idx):
+    """The lapse requirement is the worst loss over up/down/mass shocks."""
+    proj = ex1_model.Projection[idx]
+    risk = ex1_model.Enums.LifeRiskID.LAPSE
+    shock = ex1_model.Enums.LapseShockID
+    base_pv = proj.InnerProj[0].pv_net_cf(0)
+    expected = max(
+        max(base_pv - proj.InnerProj[0, risk, s].pv_net_cf(0), 0)
+        for s in (shock.UP, shock.DOWN, shock.MASS))
+    assert math.isclose(
+        proj.risk_life(0, risk), expected, rel_tol=1e-9, abs_tol=1e-9)
+
+
+@pytest.mark.parametrize("idx", IDXS)
+def test_risk_life_base_is_zero(ex1_model, idx):
+    """The unstressed baseline has no capital requirement."""
+    proj = ex1_model.Projection[idx]
+    assert proj.risk_life(0, ex1_model.Enums.LifeRiskID.BASE) == 0

--- a/lifelib/tests/libraries/test_tradlife_a_ex1.py
+++ b/lifelib/tests/libraries/test_tradlife_a_ex1.py
@@ -57,8 +57,13 @@ UNSHOCKED_RISKS = ["DISAB", "REV", "CAT"]
 
 @pytest.fixture(scope="module")
 def ex1_model():
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
-        tmp = pathlib.Path(tmp)
+    # tempfile.mkdtemp() + shutil.rmtree(ignore_errors=True) is the
+    # version-agnostic equivalent of
+    # TemporaryDirectory(ignore_cleanup_errors=...), which is only
+    # available on Python 3.10+. ignore_errors tolerates lingering file
+    # handles on Windows.
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    try:
         shutil.copytree(TRADLIFE_A_EX1_MODEL, tmp / "TradLife_A_EX1")
         shutil.copy(TRADLIFE_A_EX1_INPUT, tmp / "input.xlsx")
         model = modelx.read_model(tmp / "TradLife_A_EX1")
@@ -66,6 +71,8 @@ def ex1_model():
             yield model
         finally:
             model.close()
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
 
 
 @pytest.mark.parametrize("idx", IDXS)


### PR DESCRIPTION
## What

Adds `Projection.risk_life(t, risk)` to the `annuallife/TradLife_A_EX1` model — the Solvency II life underwriting capital requirement for each life sub-risk, computed from the inner projection (`InnerProj`) that already implements the prescribed life stresses.

```python
def risk_life(t, risk):
    base_pv = InnerProj[t].pv_net_cf(t)
    if risk == LifeRiskID.LAPSE:
        return max(
            max(base_pv - InnerProj[t, risk, shock].pv_net_cf(t), 0)
            for shock in (LapseShockID.UP, LapseShockID.DOWN, LapseShockID.MASS))
    else:
        return max(base_pv - InnerProj[t, risk].pv_net_cf(t), 0)
```

## Why

`TradLife_A_EX1` already projects the stressed PVs of net cashflows under the prescribed Solvency II life stresses via `InnerProj[t0, risk, shock]`, but nothing consumed them to produce a per-risk capital requirement. `risk_life` closes that gap.

It mirrors the `solvency2` library's `SCR_life.Life` (and, for the lapse shocks, `SCR_life.LapseRisk`): the capital requirement is the loss in the value of in-force — baseline minus stressed present value of `pv_net_cf`, floored at zero — with the lapse risk taking the worst loss across the up/down/mass shocks. Here `pv_net_cf` stands in for the net asset value.

## Notes for reviewers

- **Sign / floor convention** follows `SCR_life.Life`: `max(baseline − stressed, 0)`. Both PVs are taken at the valuation time `t` from `InnerProj`, anchored at `t`.
- Life sub-risks that `InnerProj` does not model (DISAB, REV, CAT) apply no stress, so `risk_life` returns 0 for them — consistent with the `solvency2` reference, which only overrides mortality / lapse / expense.
- Two `Interface` References (`LifeRiskID`, `LapseShockID`) were added to the `Projection` space so the formula resolves the enum constants; the `("..", "Enums", ...)` dot-path matches the sibling `Assumptions` space.
- The serialized file is byte-canonical (no trailing blank line), matching modelx's serializer output.

## Verification

Model loaded via `modelx.read_model` (Python 3.13). For policy `idx=0` (baseline `pv_net_cf(0)=8954.02`):

| risk | result | note |
|------|-------:|------|
| MORT | 946.39 | stressed lower |
| LONGV | 0.00 | stress favorable → floored |
| EXPS | 1730.46 | stressed lower |
| LAPSE | 4924.57 | worst of up 2647.40 / down −3726.78 / mass 4924.57 |
| BASE | 0.00 | unstressed |

New `lifelib/tests/libraries/test_tradlife_a_ex1.py` (45 parametrized cases, all passing) covers the non-negative floor, the per-risk floored difference, the zero requirement for unmodeled risks, the lapse worst-of-shocks branch, and the zero baseline. It mirrors the temp-dir-copy pattern in `test_tradlife_a.py`.

## Out of scope (follow-ups)

The wider `TradLife_A_EX1` model (added in #143) has no Sphinx doc page, example plot, or aggregating `SCR_life`-style correlation cell. These pre-existing gaps are left for separate work.
