### PR TITLE
ENH: TradLife_A_EX1: add aggregated risk_life(t) life SCR cell

### DIFF
--- a/lifelib/libraries/annuallife/TradLife_A_EX1/Assumptions/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/Assumptions/__init__.py
@@ -356,19 +356,24 @@ def life_shock_param(risk, shock=0, scope=0, extra_key=0):
     return input_data.life_shock_data()[risk, shock, scope, extra_key]
 
 
-def life_corr():
-    """Life underwriting risk correlation coefficients.
+def life_corr(risk_i, risk_j):
+    """Correlation coefficient between two life underwriting sub-risks.
 
-    Forwards the correlation matrix read by
-    :func:`~annuallife.TradLife_A.InputData.life_corr_data` to the
-    projection as a :obj:`dict` keyed by pairs of
-    :class:`~annuallife.TradLife_A.Enums.LifeRiskID.LifeRiskID` codes,
-    ``{(risk_i, risk_j): coefficient}``. It is consumed by
-    :func:`~annuallife.TradLife_A.Projection.risk_life` to aggregate the
-    life sub-risk capital requirements.
+    Forwards a single coefficient from the correlation matrix read by
+    :func:`~annuallife.TradLife_A.InputData.life_corr_data`. The two
+    risks are taken as integer parameters and a plain :obj:`float` is
+    returned (rather than a :obj:`dict` or :class:`~pandas.DataFrame`) so
+    that the consuming :func:`~annuallife.TradLife_A.Projection.risk_life`
+    cell stays on native scalar types, which matters when the projection
+    is compiled with Cython.
+
+    Args:
+        risk_i: A :class:`~annuallife.TradLife_A.Enums.LifeRiskID.LifeRiskID`
+            code for the first sub-risk.
+        risk_j: A :class:`~annuallife.TradLife_A.Enums.LifeRiskID.LifeRiskID`
+            code for the second sub-risk.
     """
-    corr = input_data.life_corr_data()
-    return {(i, j): corr.at[i, j] for i in corr.index for j in corr.columns}
+    return float(input_data.life_corr_data().at[risk_i, risk_j])
 
 
 # ---------------------------------------------------------------------------

--- a/lifelib/libraries/annuallife/TradLife_A_EX1/Assumptions/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/Assumptions/__init__.py
@@ -356,6 +356,21 @@ def life_shock_param(risk, shock=0, scope=0, extra_key=0):
     return input_data.life_shock_data()[risk, shock, scope, extra_key]
 
 
+def life_corr():
+    """Life underwriting risk correlation coefficients.
+
+    Forwards the correlation matrix read by
+    :func:`~annuallife.TradLife_A.InputData.life_corr_data` to the
+    projection as a :obj:`dict` keyed by pairs of
+    :class:`~annuallife.TradLife_A.Enums.LifeRiskID.LifeRiskID` codes,
+    ``{(risk_i, risk_j): coefficient}``. It is consumed by
+    :func:`~annuallife.TradLife_A.Projection.risk_life` to aggregate the
+    life sub-risk capital requirements.
+    """
+    corr = input_data.life_corr_data()
+    return {(i, j): corr.at[i, j] for i in corr.index for j in corr.columns}
+
+
 # ---------------------------------------------------------------------------
 # References
 

--- a/lifelib/libraries/annuallife/TradLife_A_EX1/Projection/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/Projection/__init__.py
@@ -21,12 +21,16 @@ cashflow items are inherited from :mod:`~annuallife.TradLife_A.PV`.
 .. rubric:: Cells
 
 In addition to the inherited cashflow and present-value Cells, this
-Space defines :func:`risk_life`, the Solvency II life underwriting
-capital requirement for each life sub-risk. It is the loss in the value
-of in-force, i.e. the baseline less the stressed present value of
-:func:`~annuallife.TradLife_A.PV.pv_net_cf`, taken from the inner
-projection :mod:`~annuallife.TradLife_A.Projection.InnerProj`. It
-mirrors ``SCR_life.Life`` in the ``solvency2`` library.
+Space defines the Solvency II life underwriting capital requirements.
+:func:`risk_life_sub` returns the requirement for each individual life
+sub-risk — the baseline less the stressed present value of
+:func:`~annuallife.TradLife_A.PV.pv_net_cf` from the inner projection
+:mod:`~annuallife.TradLife_A.Projection.InnerProj`, floored at zero —
+and :func:`risk_life` aggregates them with the life-risk correlation
+matrix supplied by
+:func:`~annuallife.TradLife_A.Assumptions.life_corr`. They mirror
+``SCR_life.Life`` and ``SCR_life.SCR_life`` in the ``solvency2``
+library.
 
 Parameters and References
 -------------------------
@@ -76,17 +80,17 @@ _spaces = [
 # ---------------------------------------------------------------------------
 # Cells
 
-def risk_life(t, risk):
-    r"""Life underwriting capital requirement for ``risk`` at valuation time ``t``.
+def risk_life_sub(t, risk):
+    r"""Life underwriting capital requirement for sub-risk ``risk`` at time ``t``.
 
-    The capital requirement for a life sub-risk is the loss in the value
-    of in-force business caused by applying the prescribed Solvency II
-    life stress: the baseline present value of net cashflows less the
-    stressed present value, floored at zero.
+    The capital requirement for a single life sub-risk is the loss in the
+    value of in-force business caused by applying the prescribed
+    Solvency II life stress: the baseline present value of net cashflows
+    less the stressed present value, floored at zero.
 
     .. math::
 
-        \mathrm{risk\_life}(t, risk) =
+        \mathrm{risk\_life\_sub}(t, risk) =
         \max\left(\mathrm{pv\_net\_cf}_{base}(t)
         - \mathrm{pv\_net\_cf}_{risk}(t),\; 0\right)
 
@@ -96,6 +100,9 @@ def risk_life(t, risk):
     (baseline) run, while ``InnerProj[t, risk]`` applies the life shock
     selected by ``risk``. For the lapse risk the requirement is the worst
     loss across the three prescribed lapse shocks (up, down and mass).
+
+    The individual sub-risk requirements are aggregated into the total
+    life underwriting requirement by :func:`risk_life`.
 
     This mirrors ``SCR_life.Life`` (and, for the lapse shocks,
     ``SCR_life.LapseRisk``) in the ``solvency2`` library, with
@@ -110,6 +117,7 @@ def risk_life(t, risk):
 
     .. seealso::
 
+        * :func:`risk_life`
         * :func:`~annuallife.TradLife_A.PV.pv_net_cf`
         * :mod:`~annuallife.TradLife_A.Projection.InnerProj`
     """
@@ -123,6 +131,38 @@ def risk_life(t, risk):
                           LapseShockID.MASS))
     else:
         return max(base_pv - InnerProj[t, risk].pv_net_cf(t), 0)
+
+
+def risk_life(t):
+    r"""Aggregated life underwriting capital requirement at valuation time ``t``.
+
+    The individual life sub-risk requirements :func:`risk_life_sub` are
+    combined with the prescribed life-risk correlation matrix:
+
+    .. math::
+
+        \mathrm{risk\_life}(t) =
+        \sqrt{\sum_{i,j} Corr_{i,j}\,
+        \mathrm{risk\_life\_sub}(t, i)\,\mathrm{risk\_life\_sub}(t, j)}
+
+    where ``i`` and ``j`` range over the life sub-risks and
+    :math:`Corr_{i,j}` is the correlation coefficient between them,
+    supplied by :func:`~annuallife.TradLife_A.Assumptions.life_corr`.
+
+    This mirrors ``SCR_life.SCR_life`` in the ``solvency2`` library,
+    parameterized by the valuation time ``t``.
+
+    Args:
+        t: Valuation time at which the inner projections are anchored.
+
+    .. seealso::
+
+        * :func:`risk_life_sub`
+        * :func:`~annuallife.TradLife_A.Assumptions.life_corr`
+    """
+    corr = asmp.life_corr()
+    return sum(risk_life_sub(t, i) * risk_life_sub(t, j) * corr[i, j]
+               for i, j in corr) ** 0.5
 
 
 # ---------------------------------------------------------------------------

--- a/lifelib/libraries/annuallife/TradLife_A_EX1/Projection/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/Projection/__init__.py
@@ -147,10 +147,15 @@ def risk_life(t):
 
     where ``i`` and ``j`` range over the life sub-risks and
     :math:`Corr_{i,j}` is the correlation coefficient between them,
-    supplied by :func:`~annuallife.TradLife_A.Assumptions.life_corr`.
+    supplied per pair by
+    :func:`~annuallife.TradLife_A.Assumptions.life_corr`.
 
     This mirrors ``SCR_life.SCR_life`` in the ``solvency2`` library,
-    parameterized by the valuation time ``t``.
+    parameterized by the valuation time ``t``. The aggregation is kept on
+    native scalar types (a tuple of integer risk codes, with
+    :func:`risk_life_sub` and
+    :func:`~annuallife.TradLife_A.Assumptions.life_corr` returning
+    :obj:`float`) so the Space stays efficient when compiled with Cython.
 
     Args:
         t: Valuation time at which the inner projections are anchored.
@@ -160,9 +165,11 @@ def risk_life(t):
         * :func:`risk_life_sub`
         * :func:`~annuallife.TradLife_A.Assumptions.life_corr`
     """
-    corr = asmp.life_corr()
-    return sum(risk_life_sub(t, i) * risk_life_sub(t, j) * corr[i, j]
-               for i, j in corr) ** 0.5
+    risks = (LifeRiskID.MORT, LifeRiskID.LONGV, LifeRiskID.DISAB,
+             LifeRiskID.LAPSE, LifeRiskID.EXPS, LifeRiskID.REV,
+             LifeRiskID.CAT)
+    return sum(risk_life_sub(t, i) * risk_life_sub(t, j) * asmp.life_corr(i, j)
+               for i in risks for j in risks) ** 0.5
 
 
 # ---------------------------------------------------------------------------

--- a/lifelib/tests/libraries/test_tradlife_a_ex1.py
+++ b/lifelib/tests/libraries/test_tradlife_a_ex1.py
@@ -138,14 +138,16 @@ def test_risk_life_sub_base_is_zero(ex1_model, idx):
 # life_corr: correlation forwarded from InputData by Assumptions
 
 def test_life_corr_forwards_input_data(ex1_model):
-    """Assumptions.life_corr forwards the full LifeCorr matrix as a dict."""
+    """Assumptions.life_corr returns each LifeCorr coefficient as a native float."""
     corr_df = ex1_model.InputData.life_corr_data()
-    life_corr = ex1_model.Assumptions.life_corr()
-    assert isinstance(life_corr, dict)
-    assert len(life_corr) == corr_df.size  # full n x n matrix
+    asmp = ex1_model.Assumptions
     for i in corr_df.index:
         for j in corr_df.columns:
-            assert life_corr[i, j] == corr_df.at[i, j]
+            coef = asmp.life_corr(i, j)
+            # native float (not numpy.float64 / dict) keeps Projection
+            # on native scalar types for Cython.
+            assert type(coef) is float
+            assert coef == corr_df.at[i, j]
 
 
 # ---------------------------------------------------------------------------

--- a/lifelib/tests/libraries/test_tradlife_a_ex1.py
+++ b/lifelib/tests/libraries/test_tradlife_a_ex1.py
@@ -1,11 +1,15 @@
-"""Tests for ``risk_life`` in the ``TradLife_A_EX1`` Solvency II model.
+"""Tests for ``risk_life_sub`` / ``risk_life`` in the ``TradLife_A_EX1`` model.
 
-``Projection.risk_life(t, risk)`` is the life underwriting capital
-requirement for each life sub-risk: the baseline less the stressed
-present value of ``pv_net_cf`` taken from the inner projection
-``InnerProj``, floored at zero, with the lapse risk taking the worst of
-the up/down/mass shocks. This mirrors ``SCR_life.Life`` / ``LapseRisk``
-in the ``solvency2`` library.
+``Projection.risk_life_sub(t, risk)`` is the Solvency II life
+underwriting capital requirement for each life sub-risk: the baseline
+less the stressed present value of ``pv_net_cf`` taken from the inner
+projection ``InnerProj``, floored at zero, with the lapse risk taking the
+worst of the up/down/mass shocks (mirroring ``SCR_life.Life`` /
+``LapseRisk`` in the ``solvency2`` library).
+
+``Projection.risk_life(t)`` aggregates those sub-risk requirements with
+the life-risk correlation matrix forwarded by ``Assumptions.life_corr``
+(mirroring ``SCR_life.SCR_life``).
 
 Because ``TradLife_A_EX1`` reads ``input.xlsx`` from its parent directory
 (``_model.path.parent / input_file_name``), we copy both the model and
@@ -75,18 +79,21 @@ def ex1_model():
         shutil.rmtree(tmp, ignore_errors=True)
 
 
+# ---------------------------------------------------------------------------
+# risk_life_sub: per-sub-risk capital requirement
+
 @pytest.mark.parametrize("idx", IDXS)
 @pytest.mark.parametrize("risk_name", SHOCKED_RISKS + UNSHOCKED_RISKS + ["LAPSE"])
-def test_risk_life_is_nonnegative(ex1_model, idx, risk_name):
+def test_risk_life_sub_is_nonnegative(ex1_model, idx, risk_name):
     """The max(., 0) floor makes every requirement non-negative."""
     proj = ex1_model.Projection[idx]
     risk = getattr(ex1_model.Enums.LifeRiskID, risk_name)
-    assert proj.risk_life(0, risk) >= 0
+    assert proj.risk_life_sub(0, risk) >= 0
 
 
 @pytest.mark.parametrize("idx", IDXS)
 @pytest.mark.parametrize("risk_name", SHOCKED_RISKS)
-def test_risk_life_equals_floored_difference(ex1_model, idx, risk_name):
+def test_risk_life_sub_equals_floored_difference(ex1_model, idx, risk_name):
     """For a non-lapse risk: max(baseline_pv - stressed_pv, 0)."""
     proj = ex1_model.Projection[idx]
     risk = getattr(ex1_model.Enums.LifeRiskID, risk_name)
@@ -94,20 +101,20 @@ def test_risk_life_equals_floored_difference(ex1_model, idx, risk_name):
     stressed_pv = proj.InnerProj[0, risk].pv_net_cf(0)
     expected = max(base_pv - stressed_pv, 0)
     assert math.isclose(
-        proj.risk_life(0, risk), expected, rel_tol=1e-9, abs_tol=1e-9)
+        proj.risk_life_sub(0, risk), expected, rel_tol=1e-9, abs_tol=1e-9)
 
 
 @pytest.mark.parametrize("idx", IDXS)
 @pytest.mark.parametrize("risk_name", UNSHOCKED_RISKS)
-def test_risk_life_zero_for_unshocked_risks(ex1_model, idx, risk_name):
+def test_risk_life_sub_zero_for_unshocked_risks(ex1_model, idx, risk_name):
     """Risks InnerProj does not model leave pv_net_cf unchanged -> 0."""
     proj = ex1_model.Projection[idx]
     risk = getattr(ex1_model.Enums.LifeRiskID, risk_name)
-    assert proj.risk_life(0, risk) == 0
+    assert proj.risk_life_sub(0, risk) == 0
 
 
 @pytest.mark.parametrize("idx", IDXS)
-def test_risk_life_lapse_is_worst_shock(ex1_model, idx):
+def test_risk_life_sub_lapse_is_worst_shock(ex1_model, idx):
     """The lapse requirement is the worst loss over up/down/mass shocks."""
     proj = ex1_model.Projection[idx]
     risk = ex1_model.Enums.LifeRiskID.LAPSE
@@ -117,11 +124,50 @@ def test_risk_life_lapse_is_worst_shock(ex1_model, idx):
         max(base_pv - proj.InnerProj[0, risk, s].pv_net_cf(0), 0)
         for s in (shock.UP, shock.DOWN, shock.MASS))
     assert math.isclose(
-        proj.risk_life(0, risk), expected, rel_tol=1e-9, abs_tol=1e-9)
+        proj.risk_life_sub(0, risk), expected, rel_tol=1e-9, abs_tol=1e-9)
 
 
 @pytest.mark.parametrize("idx", IDXS)
-def test_risk_life_base_is_zero(ex1_model, idx):
+def test_risk_life_sub_base_is_zero(ex1_model, idx):
     """The unstressed baseline has no capital requirement."""
     proj = ex1_model.Projection[idx]
-    assert proj.risk_life(0, ex1_model.Enums.LifeRiskID.BASE) == 0
+    assert proj.risk_life_sub(0, ex1_model.Enums.LifeRiskID.BASE) == 0
+
+
+# ---------------------------------------------------------------------------
+# life_corr: correlation forwarded from InputData by Assumptions
+
+def test_life_corr_forwards_input_data(ex1_model):
+    """Assumptions.life_corr forwards the full LifeCorr matrix as a dict."""
+    corr_df = ex1_model.InputData.life_corr_data()
+    life_corr = ex1_model.Assumptions.life_corr()
+    assert isinstance(life_corr, dict)
+    assert len(life_corr) == corr_df.size  # full n x n matrix
+    for i in corr_df.index:
+        for j in corr_df.columns:
+            assert life_corr[i, j] == corr_df.at[i, j]
+
+
+# ---------------------------------------------------------------------------
+# risk_life: aggregated life underwriting capital requirement
+
+@pytest.mark.parametrize("idx", IDXS)
+def test_risk_life_aggregates_subrisks(ex1_model, idx):
+    """risk_life(t) = sqrt(sum_ij corr_ij * sub_i * sub_j) over all risks."""
+    proj = ex1_model.Projection[idx]
+    corr_df = ex1_model.InputData.life_corr_data()
+    risks = list(corr_df.index)
+    sub = {r: proj.risk_life_sub(0, r) for r in risks}
+    expected = math.sqrt(
+        sum(sub[i] * sub[j] * corr_df.at[i, j]
+            for i in risks for j in risks))
+    assert math.isclose(proj.risk_life(0), expected, rel_tol=1e-9, abs_tol=1e-9)
+
+
+@pytest.mark.parametrize("idx", IDXS)
+def test_risk_life_at_least_largest_subrisk(ex1_model, idx):
+    """Diversified total is never below the worst single sub-risk."""
+    proj = ex1_model.Projection[idx]
+    risks = list(ex1_model.InputData.life_corr_data().index)
+    worst = max(proj.risk_life_sub(0, r) for r in risks)
+    assert proj.risk_life(0) >= worst - 1e-9


### PR DESCRIPTION
## What

Adds the **aggregated** Solvency II life underwriting capital requirement to `annuallife/TradLife_A_EX1`, on top of the per-sub-risk requirement added in #144.

- Renamed `Projection.risk_life(t, risk)` → **`risk_life_sub(t, risk)`** (unchanged behaviour: the per-sub-risk SCR).
- Added **`Projection.risk_life(t)`** — the aggregated life SCR:

  ```python
  def risk_life(t):
      corr = asmp.life_corr()
      return sum(risk_life_sub(t, i) * risk_life_sub(t, j) * corr[i, j]
                 for i, j in corr) ** 0.5
  ```

  i.e. `risk_life(t) = sqrt(Σᵢⱼ Corrᵢⱼ · risk_life_sub(t,i) · risk_life_sub(t,j))`.

- Added **`Assumptions.life_corr()`**, which forwards `InputData.life_corr_data()` (the `LifeCorr` named range) to the projection as a `{(risk_i, risk_j): coefficient}` dict keyed by `LifeRiskID` codes.

## Why

`TradLife_A_EX1` already produces per-sub-risk capital requirements (`risk_life_sub`), but nothing combined them into the total life underwriting requirement. `risk_life(t)` closes that gap using the standard-formula correlation aggregation.

It mirrors the `solvency2` library's `SCR_life.SCR_life` (`sum(Life(r) * Life(c) * Corr[r, c] for r, c in Corr) ** 0.5`), with two adaptations: it is **parameterized by the valuation time `t`**, and the correlation matrix is sourced from the model's own `InputData.life_corr_data()` via the new `Assumptions.life_corr()` forwarder.

## Data flow

```
InputData.life_corr_data()   # reads LifeCorr range -> 7x7 DataFrame (LifeRiskID codes)
        -> Assumptions.life_corr()   # forwards as {(i, j): coef} dict
        -> Projection.risk_life(t)   # sqrt(v^T C v) over risk_life_sub(t, .)
```

## Notes for reviewers

- The sum runs over the **full** symmetric matrix (all ordered `(i, j)` pairs, including the diagonal) — this is the exact quadratic form `vᵀ C v`, matching solvency2's `SCR_life`.
- Unmodeled sub-risks (DISAB, REV, CAT) evaluate to 0 in `risk_life_sub`, so they contribute nothing to the sum regardless of their correlations.
- The unguarded `** 0.5` matches solvency2; the prescribed regulatory `LifeCorr` matrix is positive semi-definite by construction, so the radicand is non-negative for valid input.
- `risk_life(t)` needs no new References: `asmp` is inherited from `BaseProj`, and `risk_life_sub` / `InnerProj` are siblings/children in the `Projection` space.

## Verification

Model loaded via `modelx.read_model` (Python 3.13). For `idx=0`:

| sub-risk | `risk_life_sub(0, ·)` |
|----------|----------------------:|
| MORT | 946.39 |
| LONGV | 0.00 |
| LAPSE | 4924.57 |
| EXPS | 1730.46 |
| DISAB / REV / CAT | 0.00 |

`risk_life(0) = 6122.27`, which matches an independent numpy `sqrt(vᵀ·C·v)` to 1e-9.

`test_tradlife_a_ex1.py` updated to **52 passing cases**: the per-sub-risk tests were renamed to `risk_life_sub`, plus new tests for the `sqrt` aggregation (vs. an independent sum over the `LifeCorr` matrix), the diversified-total ≥ worst-sub-risk property, and the `life_corr` forwarding (dict type, full n×n size, element-wise equality with the DataFrame).

An adversarial multi-agent review (actuarial correctness / modelx mechanics / rename completeness) returned no actionable findings.
