### PR TITLE
DOC: TradLife_A_EX1: add SCR cashflow and life-risk radar plot scripts

### DIFF
--- a/lifelib/libraries/annuallife/draw_charts_radar.py
+++ b/lifelib/libraries/annuallife/draw_charts_radar.py
@@ -1,0 +1,190 @@
+"""
+Draw radar charts
+=================
+
+This module contains :func:`draw_radar`, a function to draw radar charts a.k.a
+spyder charts.
+
+The code in this module is derived from the matplot example,
+`Radar chart (aka spider or star chart) <https://matplotlib.org/gallery/specialty_plots/radar_chart.html>`_.
+
+See `Matplotlib license <https://matplotlib.org/users/license.html>`_.
+"""
+
+import numpy as np
+import pandas as pd
+
+import matplotlib.pyplot as plt
+from matplotlib.path import Path
+from matplotlib.spines import Spine
+from matplotlib.projections.polar import PolarAxes
+from matplotlib.projections import register_projection
+
+
+def radar_factory(num_vars, frame='circle'):
+    """Create a radar chart with `num_vars` axes.
+
+    This function creates a RadarAxes projection and registers it.
+
+    Parameters
+    ----------
+    num_vars : int
+        Number of variables for radar chart.
+    frame : {'circle' | 'polygon'}
+        Shape of frame surrounding axes.
+
+    """
+    # calculate evenly-spaced axis angles
+    theta = np.linspace(0, 2*np.pi, num_vars, endpoint=False)
+
+    def draw_poly_patch(self):
+        # rotate theta such that the first axis is at the top
+        verts = unit_poly_verts(theta + np.pi / 2)
+        return plt.Polygon(verts, closed=True, edgecolor='k')
+
+    def draw_circle_patch(self):
+        # unit circle centered on (0.5, 0.5)
+        return plt.Circle((0.5, 0.5), 0.5)
+
+    patch_dict = {'polygon': draw_poly_patch, 'circle': draw_circle_patch}
+    if frame not in patch_dict:
+        raise ValueError('unknown value for `frame`: %s' % frame)
+
+    class RadarAxes(PolarAxes):
+
+        name = 'radar'
+        # use 1 line segment to connect specified points
+        RESOLUTION = 1
+        # define draw_frame method
+        draw_patch = patch_dict[frame]
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            # rotate plot such that the first axis is at the top
+            self.set_theta_zero_location('N')
+
+        def fill(self, *args, closed=True, **kwargs):
+            """Override fill so that line is closed by default"""
+            return super().fill(closed=closed, *args, **kwargs)
+
+        def plot(self, *args, **kwargs):
+            """Override plot so that line is closed by default"""
+            lines = super().plot(*args, **kwargs)
+            for line in lines:
+                self._close_line(line)
+
+        def _close_line(self, line):
+            x, y = line.get_data()
+            # FIXME: markers at x[0], y[0] get doubled-up
+            if x[0] != x[-1]:
+                x = np.concatenate((x, [x[0]]))
+                y = np.concatenate((y, [y[0]]))
+                line.set_data(x, y)
+
+        def set_varlabels(self, labels):
+            self.set_thetagrids(np.degrees(theta), labels)
+
+        def _gen_axes_patch(self):
+            return self.draw_patch()
+
+        def _gen_axes_spines(self):
+            if frame == 'circle':
+                return super()._gen_axes_spines()
+            # The following is a hack to get the spines (i.e. the axes frame)
+            # to draw correctly for a polygon frame.
+
+            # spine_type must be 'left', 'right', 'top', 'bottom', or `circle`.
+            spine_type = 'circle'
+            verts = unit_poly_verts(theta + np.pi / 2)
+            # close off polygon by repeating first vertex
+            verts.append(verts[0])
+            path = Path(verts)
+
+            spine = Spine(self, spine_type, path)
+            spine.set_transform(self.transAxes)
+            return {'polar': spine}
+
+    register_projection(RadarAxes)
+    return theta
+
+
+def unit_poly_verts(theta):
+    """Return vertices of polygon for subplot axes.
+
+    This polygon is circumscribed by a unit circle centered at (0.5, 0.5)
+    """
+    x0, y0, r = [0.5] * 3
+    verts = [(r*np.cos(t) + x0, r*np.sin(t) + y0) for t in theta]
+    return verts
+
+
+def get_rgrids(max_value, rgrid_count):
+    """Calculate radial grid steps and return it as a list"""
+
+    import math
+
+    digits = math.floor(math.log(max_value, 10))
+    scale = max_value / (10**digits)
+
+    ubound = math.ceil(scale) * (10**digits)
+    step = ubound / (rgrid_count+1)
+
+    return list(step * i for i in range(1, rgrid_count+1))
+
+
+def draw_radar(df: pd.DataFrame, ax_title=None, fig_title=None,
+               colors=('b', 'r', 'g', 'm', 'y')):
+    """Draw radar chart"""
+
+    spoke_count, line_count = df.shape
+
+    theta = radar_factory(spoke_count, frame='polygon')
+    spoke_labels = list(df.index)
+
+    fig, ax = plt.subplots(subplot_kw=dict(projection='radar'))
+    fig.subplots_adjust(wspace=0.25, hspace=0.20, top=0.85, bottom=0.05)
+
+    if len(colors) < line_count:
+        colors = (colors * (line_count // len(colors) + 1))[:line_count]
+
+    max_value = df.max().max()
+    if max_value > 0:   # skip radial grids when every value is zero
+        ax.set_rgrids(get_rgrids(max_value, 4))
+    if ax_title:
+        ax.set_title(ax_title, weight='normal', size='medium',
+                     position=(0.5, 1.09),
+                     horizontalalignment='center', verticalalignment='center')
+
+    for col, color in zip(df, colors):
+        ax.plot(theta, list(df[col]), color=color)
+        ax.fill(theta, list(df[col]), facecolor=color, alpha=0.25)
+
+    ax.set_varlabels(spoke_labels)
+
+    # add legend relative to top-left plot
+    labels = list(df.columns)
+    legend = ax.legend(labels, loc=(0.9, .95),
+                       labelspacing=0.1)
+
+    fig.text(0.5, 0.965, fig_title,
+             horizontalalignment='center', color='black', weight='bold',
+             size='large')
+
+    return ax
+
+
+if __name__ == '__main__':
+
+    data = {'Line 1': [0.88, 1.30, 0.50, 0.03],
+            'Line 2': [0.07, 0.95, 0.04, 0.05],
+            'Line 3': [0.01, 0.02, 0.85, 0.19],
+            'Line 4': [0.02, 0.01, 0.07, 0.60],
+            'Line 5': [0.01, 0.01, 0.02, 0.71]}
+
+    index = ['Sulfate', 'Nitrate', 'EC', 'OC1']
+
+    df = pd.DataFrame(data=data, index=index)
+
+    draw_radar(df, fig_title='Sample Radar')
+
+    plt.show()

--- a/lifelib/libraries/annuallife/plot_scr_cashflows_tradlife_a_ex1.py
+++ b/lifelib/libraries/annuallife/plot_scr_cashflows_tradlife_a_ex1.py
@@ -1,0 +1,62 @@
+"""
+TradLife_A_EX1: SCR shock cashflows
+===================================
+
+Net liability cashflows under the prescribed Solvency II life shock
+scenarios for selected policies, projected by the :mod:`~annuallife`
+``TradLife_A_EX1`` model.
+
+For each policy the inner projection ``InnerProj[t0, risk, shock]`` is
+re-run from the valuation time ``t0`` under every life stress, and the
+per-period net cashflow ``net_cf`` is charted from ``t0`` to the end of
+the projection. The mass-lapse line drops sharply at ``t0`` because a
+fraction of the policies surrenders instantly under that shock.
+
+.. seealso::
+    * The :mod:`~annuallife` library
+"""
+import modelx as mx
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+sns.set_theme(style="darkgrid")
+
+model = mx.read_model("TradLife_A_EX1")
+LifeRiskID = model.Enums.LifeRiskID
+LapseShockID = model.Enums.LapseShockID
+
+# (label, risk, shock) for each prescribed life stress
+scenarios = [
+    ('base', LifeRiskID.BASE, 0),
+    ('mort', LifeRiskID.MORT, 0),
+    ('longev', LifeRiskID.LONGV, 0),
+    ('lapse(up)', LifeRiskID.LAPSE, LapseShockID.UP),
+    ('lapse(down)', LifeRiskID.LAPSE, LapseShockID.DOWN),
+    ('lapse(mass)', LifeRiskID.LAPSE, LapseShockID.MASS),
+    ('exps', LifeRiskID.EXPS, 0),
+]
+
+
+def draw(idx, t0):
+
+    fig, ax = plt.subplots()
+    fig.suptitle('Net Cashflows')
+
+    title = 'Policy index: ' + str(idx) + ', Shock at ' + str(t0)
+
+    proj = model.Projection[idx]
+    last_t = proj.proj_len()
+
+    data = {}
+    for label, risk, shock in scenarios:
+        inner = proj.InnerProj[t0, risk, shock]
+        data[label] = [inner.net_cf(t) for t in range(t0, last_t + 1)]
+
+    return pd.DataFrame(
+        data, index=range(t0, last_t + 1)).plot(
+        ax=ax, kind='line', title=title)
+
+
+# idx 40 / 170 correspond to PolicyID 41 / 171 in simplelife (0-based).
+for idx, t0 in [(40, 5), (170, 5)]:
+    draw(idx, t0)

--- a/lifelib/libraries/annuallife/plot_scr_radar_tradlife_a_ex1.py
+++ b/lifelib/libraries/annuallife/plot_scr_radar_tradlife_a_ex1.py
@@ -1,0 +1,45 @@
+"""
+TradLife_A_EX1: Life SCR radar chart
+====================================
+
+Radar charts of the Solvency II life sub-risk capital requirements for
+selected policies, projected by the :mod:`~annuallife` ``TradLife_A_EX1``
+model. Each spoke of the radar chart represents a life sub-risk
+(:func:`~annuallife.TradLife_A.Projection.risk_life_sub`), and each ring
+shows the sizes of those sub-risks at a projection time ``t``.
+
+.. seealso::
+    * The :mod:`~annuallife` library
+"""
+import modelx as mx
+import pandas as pd
+from draw_charts_radar import draw_radar
+
+model = mx.read_model("TradLife_A_EX1")
+LifeRiskID = model.Enums.LifeRiskID
+
+# (label, LifeRiskID code) for each radar spoke
+risks = [('mort', LifeRiskID.MORT),
+         ('longev', LifeRiskID.LONGV),
+         ('disab', LifeRiskID.DISAB),
+         ('exps', LifeRiskID.EXPS),
+         ('lapse', LifeRiskID.LAPSE)]
+
+
+def draw(idx):
+
+    proj = model.Projection[idx]
+
+    data = {}
+    for t in range(0, 20, 5):
+        data['t=' + str(t)] = pd.Series(
+            {label: proj.risk_life_sub(t, risk) for label, risk in risks})
+
+    draw_radar(pd.DataFrame(data),
+               ax_title='Policy index: ' + str(idx),
+               fig_title='SCR Life Risks')
+
+
+# idx 40 / 170 correspond to PolicyID 41 / 171 in simplelife (0-based).
+for i in (40, 170):
+    draw(i)


### PR DESCRIPTION
## What

Adds two sphinx-gallery example scripts that visualize the `annuallife/TradLife_A_EX1` Solvency II calculations, mirroring `plot_scr_cashflows.py` and `plot_scr_radar.py` in the `solvency2` library.

- **`plot_scr_cashflows_tradlife_a_ex1.py`** — line chart of the per-period net cashflow (`net_cf`) under each prescribed life shock, re-running the inner projection `InnerProj[t0, risk, shock]` from the valuation time `t0` (base, mort, longev, lapse up/down/mass, exps). The mass-lapse line drops sharply at `t0` as a fraction of policies surrenders instantly.
- **`plot_scr_radar_tradlife_a_ex1.py`** — radar charts of the life sub-risk capital requirements (`risk_life_sub`) by projection time `t`, one spoke per sub-risk.
- **`draw_charts_radar.py`** — the radar helper, copied from `solvency2` so the script is self-contained.

All three live in `lifelib/libraries/annuallife/`. The two `plot_*.py` files are auto-discovered in the annuallife gallery subsection; `draw_charts_radar.py` is excluded from gallery execution (no `plot_` prefix) but importable by the radar script — exactly as in `solvency2`.

## Notes for reviewers

- **Policies**: `idx = 40` and `170` (PolicyID 41 / 171 in simplelife, 0-based), matching the policies the solvency2 originals use.
- **Hardening**: `draw_radar` now skips radial grids when every value is zero, avoiding a `math domain error` in `get_rgrids` (`math.log(0)`) for fully run-off / zero-SCR rings — relevant because the radar legitimately feeds sparse data (longev/disab are 0 for this protection book, and a term policy's final ring is all zero). `get_rgrids` itself is unchanged from the solvency2 original.
- No `plt.show()` — sphinx-gallery captures figures automatically, consistent with the existing annuallife plot scripts.

## Verification

Both scripts were run headless (`Agg`) against the model and produce the expected figures:

- **Cashflows (idx 40, shock at t=5):** net-cashflow lines diverge by shock; `lapse(mass)` dips to ≈ −2,200 at t=5 then recovers.
- **Radar (idx 170):** `lapse` dominant (~19k), `mort` moderate, `exps` small, `longev`/`disab` at the center, with rings for `t=0,5,10,15` shrinking over the run-off.

An adversarial review (gallery/convention + robustness) found the scripts correct and idiomatic; its one actionable item (the `get_rgrids` fragility) is addressed by the guard above.
