### PR TITLE
REF: TradLife_A_EX1: keep BaseProj unchanged, move life shocks into InnerProj

### DIFF
--- a/lifelib/libraries/annuallife/TradLife_A_EX1/BaseProj/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/BaseProj/__init__.py
@@ -613,17 +613,7 @@ def claims_surr_pp(t):
 
 
 def expense_acq_pp(t):
-    """Acquisition expense per policy at time t.
-
-    Returns the base (unshocked) acquisition expense. Overridden in
-    :mod:`~annuallife.TradLife_A.Projection.InnerProj` to apply the
-    expense life shock; see :func:`base_expense_acq_pp`.
-    """
-    return base_expense_acq_pp(t)
-
-
-def base_expense_acq_pp(t):
-    """Base acquisition expense per policy at time t"""
+    """Acquisition expense per policy at time t"""
     if t == 0:
         return (ann_prem_pp(t) * asmp.exps_acq_ann_prem()[idx]
                 + (sum_assured(t) * asmp.exps_acq_sa()[idx] + asmp.exps_acq_pol()[idx])
@@ -641,17 +631,7 @@ def commissions_init_pp(t):
 
 
 def commissions_ren_pp(t):
-    """Renewal commission per policy at time t.
-
-    Returns the base (unshocked) renewal commission. Overridden in
-    :mod:`~annuallife.TradLife_A.Projection.InnerProj` to apply the
-    expense life shock; see :func:`base_commissions_ren_pp`.
-    """
-    return base_commissions_ren_pp(t)
-
-
-def base_commissions_ren_pp(t):
-    """Base renewal commission per policy at time t"""
+    """Renewal commission per policy at time t"""
     if t == 0:
         return 0
     elif t < asmp.comm_ren_term()[idx]:
@@ -661,17 +641,7 @@ def base_commissions_ren_pp(t):
 
 
 def expense_maint_pp(t):
-    """Maintenance expense per policy at time t.
-
-    Returns the base (unshocked) maintenance expense. Overridden in
-    :mod:`~annuallife.TradLife_A.Projection.InnerProj` to apply the
-    expense life shock; see :func:`base_expense_maint_pp`.
-    """
-    return base_expense_maint_pp(t)
-
-
-def base_expense_maint_pp(t):
-    """Base maintenance expense per policy at time t"""
+    """Maintenance expense per policy at time t"""
     return (ann_prem_pp(t) * asmp.exps_maint_ann_prem()[idx]
             + (sum_assured(t) * asmp.exps_maint_sa()[idx] + asmp.exps_maint_pol()[idx])
             * inflation_factor(t))
@@ -735,17 +705,6 @@ def proj_len():
 
 
 def mort_rate(x):
-    """Mortality rate at age ``x``.
-
-    Returns the base (unshocked) mortality rate. Overridden in
-    :mod:`~annuallife.TradLife_A.Projection.InnerProj` to apply the
-    mortality / longevity life shock; see :func:`base_mort_rate` for
-    the underlying table lookup.
-    """
-    return base_mort_rate(x)
-
-
-def base_mort_rate(x):
     """Base mortality rate at age ``x``"""
 
     return asmp.mortality_tables()[x, asmp.mort_array_index()[idx]]
@@ -785,9 +744,9 @@ def mort_factor(y):
     return asmp.asmp_tables()[min(y, asmp.asmp_table_len() - 1), asmp.mort_factor_index()[idx]]
 
 
-def lapse_rate(t):
+def lapse_rate(y):
     """Surrender Rate"""
-    return base_lapse_rate(t)
+    return asmp.asmp_tables()[min(y, asmp.asmp_table_len() - 1), asmp.lapse_rate_index()[idx]]
 
 
 def ann_prem_rate():
@@ -970,24 +929,13 @@ def last_mort_age():
 def inflation_factor(t):
     """Inflation factor at time ``t`` used to adjust expense cashflows.
 
-    Compounded from :func:`inflation_rate` starting from
-    ``inflation_factor(0) = 1``.
+    Compounded from :func:`~annuallife.TradLife_A.Assumptions.inflation_rate`
+    starting from ``inflation_factor(0) = 1``.
     """
     if t == 0:
         return 1
     else:
-        return inflation_factor(t-1) * (1 + inflation_rate())
-
-
-def inflation_rate():
-    """Annual expense inflation rate driving :func:`inflation_factor`.
-
-    Returns the base (unshocked) expense inflation rate from
-    :func:`~annuallife.TradLife_A.Assumptions.inflation_rate`. Overridden
-    in :mod:`~annuallife.TradLife_A.Projection.InnerProj` to apply the
-    expense-inflation life shock.
-    """
-    return asmp.inflation_rate()
+        return inflation_factor(t-1) * (1 + asmp.inflation_rate())
 
 
 def disc_rate_mth(t):
@@ -997,11 +945,6 @@ def disc_rate_mth(t):
     :func:`Economic[scen_id].disc_rate_mth<annuallife.TradLife_A.Economic.disc_rate_mth>`.
     """
     return scen.disc_rate_mth(t)
-
-
-def base_lapse_rate(y):
-    """Surrender Rate"""
-    return asmp.asmp_tables()[min(y, asmp.asmp_table_len() - 1), asmp.lapse_rate_index()[idx]]
 
 
 # ---------------------------------------------------------------------------

--- a/lifelib/libraries/annuallife/TradLife_A_EX1/Projection/InnerProj/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/Projection/InnerProj/__init__.py
@@ -102,25 +102,34 @@ def claims_surr(t):
 
 
 def lapse_rate(t):
-    """Surrender Rate"""
+    """Surrender Rate
+
+    The unstressed rate is taken from the outer projection
+    (:func:`~annuallife.TradLife_A.BaseProj.lapse_rate`); the lapse-up /
+    lapse-down shocks scale it (capped by the ``LIMIT`` factor), while the
+    mass-lapse shock leaves the ongoing rate unchanged (it is modelled by
+    :func:`pols_lapse_mass` instead).
+    """
+    base = _space._parent._parent.lapse_rate(t)
+
     if not risk == LifeRiskID.LAPSE:
-        return base_lapse_rate(t)
+        return base
 
     elif shock == LapseShockID.UP:
         shock_factor = 1 + asmp.life_shock_param(risk, shock)
         shock_limit = asmp.life_shock_param(risk, shock, extra_key=ExtraKeyID.LIMIT)
-        return min(shock_factor * base_lapse_rate(t), shock_limit)
+        return min(shock_factor * base, shock_limit)
 
     elif shock == LapseShockID.DOWN:
         shock_factor = 1 - asmp.life_shock_param(risk, shock)
         shock_limit = asmp.life_shock_param(risk, shock, extra_key=ExtraKeyID.LIMIT)
-        return max(shock_factor * base_lapse_rate(t), base_lapse_rate(t) - shock_limit)
+        return max(shock_factor * base, base - shock_limit)
 
     elif shock == LapseShockID.MASS:
         # The mass-lapse shock is an instantaneous discontinuance at t0
         # modelled by pols_lapse_mass / pols_if_beg1, not an elevated
         # surrender rate; ongoing surrenders stay at the base rate.
-        return base_lapse_rate(t)
+        return base
 
     else:
         raise ValueError(f'invalid lapse shock id: {shock}')
@@ -129,84 +138,110 @@ def lapse_rate(t):
 def mort_rate(x):
     """Mortality rate at age ``x`` with the mortality / longevity shock applied.
 
-    Under the ``MORT`` risk the base mortality rate is increased and
-    under the ``LONGV`` risk it is decreased, by the factor read from
-    the ``LifeShocks`` input via
+    The unstressed rate is taken from the outer projection
+    (:func:`~annuallife.TradLife_A.BaseProj.mort_rate`). Under the
+    ``MORT`` risk it is increased and under the ``LONGV`` risk it is
+    decreased, by the factor read from the ``LifeShocks`` input via
     :func:`~annuallife.TradLife_A.Assumptions.life_shock_param`. For any
-    other risk the base rate is returned unchanged.
+    other risk the unstressed rate is returned unchanged.
     """
+    base = _space._parent._parent.mort_rate(x)
+
     if risk == LifeRiskID.MORT:
-        return base_mort_rate(x) * (1 + asmp.life_shock_param(risk))
+        return base * (1 + asmp.life_shock_param(risk))
 
     elif risk == LifeRiskID.LONGV:
-        return base_mort_rate(x) * (1 - asmp.life_shock_param(risk))
+        return base * (1 - asmp.life_shock_param(risk))
 
     else:
-        return base_mort_rate(x)
+        return base
 
 
 def expense_acq_pp(t):
     """Acquisition expense per policy with the expense shock applied.
 
-    Under the ``EXPS`` risk the base acquisition expense is increased by
-    the factor read from the ``LifeShocks`` input via
+    Recomputes the acquisition expense locally (mirroring
+    :func:`~annuallife.TradLife_A.BaseProj.expense_acq_pp`) so it uses
+    this Space's stressed :func:`inflation_factor`, then under the
+    ``EXPS`` risk increases it by the factor read from the ``LifeShocks``
+    input via
     :func:`~annuallife.TradLife_A.Assumptions.life_shock_param`. For any
-    other risk the base amount is returned unchanged.
+    other risk the unstressed amount is returned.
     """
+    if t == 0:
+        base = (ann_prem_pp(t) * asmp.exps_acq_ann_prem()[idx]
+                + (sum_assured(t) * asmp.exps_acq_sa()[idx] + asmp.exps_acq_pol()[idx])
+                * inflation_factor(t) / inflation_factor(0))
+    else:
+        base = 0
+
     if risk == LifeRiskID.EXPS:
-        return base_expense_acq_pp(t) * (1 + asmp.life_shock_param(risk))
+        return base * (1 + asmp.life_shock_param(risk))
 
     else:
-        return base_expense_acq_pp(t)
+        return base
 
 
 def expense_maint_pp(t):
     """Maintenance expense per policy with the expense shock applied.
 
-    Under the ``EXPS`` risk the base maintenance expense is increased by
-    the factor read from the ``LifeShocks`` input via
+    Recomputes the maintenance expense locally (mirroring
+    :func:`~annuallife.TradLife_A.BaseProj.expense_maint_pp`) so it uses
+    this Space's stressed :func:`inflation_factor`, then under the
+    ``EXPS`` risk increases it by the factor read from the ``LifeShocks``
+    input via
     :func:`~annuallife.TradLife_A.Assumptions.life_shock_param`. For any
-    other risk the base amount is returned unchanged.
+    other risk the unstressed amount is returned.
     """
+    base = (ann_prem_pp(t) * asmp.exps_maint_ann_prem()[idx]
+            + (sum_assured(t) * asmp.exps_maint_sa()[idx] + asmp.exps_maint_pol()[idx])
+            * inflation_factor(t))
+
     if risk == LifeRiskID.EXPS:
-        return base_expense_maint_pp(t) * (1 + asmp.life_shock_param(risk))
+        return base * (1 + asmp.life_shock_param(risk))
 
     else:
-        return base_expense_maint_pp(t)
+        return base
 
 
 def commissions_ren_pp(t):
     """Renewal commission per policy with the expense shock applied.
 
-    Under the ``EXPS`` risk the base renewal commission is increased by
-    the factor read from the ``LifeShocks`` input via
+    The unstressed renewal commission is taken from the outer projection
+    (:func:`~annuallife.TradLife_A.BaseProj.commissions_ren_pp`); under
+    the ``EXPS`` risk it is increased by the factor read from the
+    ``LifeShocks`` input via
     :func:`~annuallife.TradLife_A.Assumptions.life_shock_param`. For any
-    other risk the base amount is returned unchanged.
+    other risk the unstressed amount is returned unchanged.
     """
+    base = _space._parent._parent.commissions_ren_pp(t)
+
     if risk == LifeRiskID.EXPS:
-        return base_commissions_ren_pp(t) * (1 + asmp.life_shock_param(risk))
+        return base * (1 + asmp.life_shock_param(risk))
 
     else:
-        return base_commissions_ren_pp(t)
+        return base
 
 
-def inflation_rate():
-    """Expense inflation rate with the expense-inflation shock applied.
+def inflation_factor(t):
+    """Expense inflation factor with the expense-inflation shock applied.
 
-    Under the ``EXPS`` risk the base expense inflation rate is increased
-    by the ``INFL`` factor read from the ``LifeShocks`` input via
-    :func:`~annuallife.TradLife_A.Assumptions.life_shock_param` (a +1
-    percentage-point stress to the annual expense inflation rate). The
-    inherited :func:`~annuallife.TradLife_A.BaseProj.inflation_factor`
-    then compounds at this stressed rate, so future expense cashflows
-    inflate faster. For any other risk the base rate is returned
-    unchanged.
+    Overrides :func:`~annuallife.TradLife_A.BaseProj.inflation_factor` to
+    compound at a stressed inflation rate under the ``EXPS`` risk: the
+    base rate plus the ``INFL`` factor read from the ``LifeShocks`` input
+    via :func:`~annuallife.TradLife_A.Assumptions.life_shock_param` (a +1
+    percentage-point stress). The locally recomputed expenses
+    (:func:`expense_maint_pp`, :func:`expense_acq_pp`) therefore inflate
+    faster. For any other risk it equals the unstressed factor.
     """
-    if risk == LifeRiskID.EXPS:
-        return asmp.inflation_rate() + asmp.life_shock_param(risk, extra_key=ExtraKeyID.INFL)
+    if t == 0:
+        return 1
 
-    else:
-        return asmp.inflation_rate()
+    rate = asmp.inflation_rate()
+    if risk == LifeRiskID.EXPS:
+        rate += asmp.life_shock_param(risk, extra_key=ExtraKeyID.INFL)
+
+    return inflation_factor(t - 1) * (1 + rate)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Refactors `annuallife/TradLife_A_EX1` so that **`BaseProj` is byte-identical to `TradLife_A.BaseProj`**, and all the Solvency II life-shock logic lives in the inner projection (`Projection.InnerProj`) instead.

Previously, `BaseProj` carried a `base_XXX` / `XXX` split (and a local `inflation_rate` cell) purely so `InnerProj` could override the wrappers to apply shocks. That made the EX1 `BaseProj` diverge from `TradLife_A`. This PR removes that divergence.

## Changes

- **`BaseProj`** → reverted to be identical to `TradLife_A.BaseProj` (drops the 6 `base_*` / `inflation_rate` cells and the wrapper edits).
- **`InnerProj`** → now applies every shock itself:
  - **`mort_rate`, `lapse_rate`, `commissions_ren_pp`** take the unstressed value from the outer projection via `_space._parent._parent.<cell>` (the same parent-reference idiom `pols_if` already uses) and apply the shock.
  - **`expense_acq_pp`, `expense_maint_pp`** are recomputed locally (mirroring the `BaseProj` formula) so they use `InnerProj`'s stressed `inflation_factor`, then apply the expense load shock.
  - the `inflation_rate` override is replaced by an **`inflation_factor` override** that re-derives the recursion at the stressed inflation rate.

## Why

Keeping `BaseProj` unchanged from `TradLife_A` keeps the EX1 model's diff focused on what's genuinely new (the inner projection and the SCR / risk-margin cells), at the cost of a little duplication in `InnerProj` for the expense/inflation cells (these can't use the parent reference because the inflation stress compounds over time).

## Verification

`risk_life_sub` (all 7 sub-risks at t=0 and t=5), `risk_life`, `risk_margin` (t=0 and t=3) and `pv_net_cf` are **unchanged** — verified to match the pre-refactor baseline exactly for `idx` 0, 100 and 200, e.g. `idx 0`: `pv_net_cf(0)=8954.02`, `risk_life(0)=6122.27`, `risk_margin(0)=2429.31`. The EXPS path genuinely stresses inflation (inner `inflation_factor(5)=1.051` vs base `1`).

`lifelib/tests/libraries/test_tradlife_a_ex1.py` — **62 tests pass**.

## Notes for reviewers

- No behavior change; this is a pure refactor (identical outputs).
- `InnerProj` stays Cython-friendly: the parent reference returns a native `float`, and the expense/inflation overrides use native scalar arithmetic.
- Docs are intentionally not updated in this PR.
