### PR TITLE
DOC: TradLife_A_EX1: document the model as a delta of TradLife_A

### DIFF
--- a/doc/source/libraries/annuallife/TradLife_A_EX1.rst
+++ b/doc/source/libraries/annuallife/TradLife_A_EX1.rst
@@ -1,0 +1,15 @@
+The **TradLife_A_EX1** Model
+==================================
+
+.. automodule:: annuallife.TradLife_A_EX1
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   TradLife_A_EX1/InputData
+   TradLife_A_EX1/PolicyAttrs
+   TradLife_A_EX1/Assumptions
+   TradLife_A_EX1/Projection
+   TradLife_A_EX1/InnerProj
+   TradLife_A_EX1/Enums

--- a/doc/source/libraries/annuallife/TradLife_A_EX1/Assumptions.rst
+++ b/doc/source/libraries/annuallife/TradLife_A_EX1/Assumptions.rst
@@ -1,0 +1,14 @@
+The **Assumptions** Space (TradLife_A_EX1)
+==========================================
+
+.. automodule:: annuallife.TradLife_A_EX1.Assumptions
+
+
+Cells Descriptions
+------------------
+
+.. autofunction:: life_shock_param
+
+.. autofunction:: life_corr
+
+.. autofunction:: coc_rate

--- a/doc/source/libraries/annuallife/TradLife_A_EX1/Enums.rst
+++ b/doc/source/libraries/annuallife/TradLife_A_EX1/Enums.rst
@@ -1,0 +1,4 @@
+The **Enums** Space (TradLife_A_EX1)
+====================================
+
+.. automodule:: annuallife.TradLife_A_EX1.Enums

--- a/doc/source/libraries/annuallife/TradLife_A_EX1/InnerProj.rst
+++ b/doc/source/libraries/annuallife/TradLife_A_EX1/InnerProj.rst
@@ -1,0 +1,30 @@
+The **InnerProj** Space (TradLife_A_EX1)
+========================================
+
+.. automodule:: annuallife.TradLife_A_EX1.Projection.InnerProj
+
+
+Cells Descriptions
+------------------
+
+.. autofunction:: pols_if
+
+.. autofunction:: pols_if_beg1
+
+.. autofunction:: pols_lapse_mass
+
+.. autofunction:: claims_surr
+
+.. autofunction:: claims_surr_mass_pp
+
+.. autofunction:: mort_rate
+
+.. autofunction:: lapse_rate
+
+.. autofunction:: expense_acq_pp
+
+.. autofunction:: expense_maint_pp
+
+.. autofunction:: commissions_ren_pp
+
+.. autofunction:: inflation_factor

--- a/doc/source/libraries/annuallife/TradLife_A_EX1/InputData.rst
+++ b/doc/source/libraries/annuallife/TradLife_A_EX1/InputData.rst
@@ -1,0 +1,16 @@
+The **InputData** Space (TradLife_A_EX1)
+========================================
+
+.. automodule:: annuallife.TradLife_A_EX1.InputData
+
+
+Cells Descriptions
+------------------
+
+.. autofunction:: life_shock_data
+
+.. autofunction:: life_corr_data
+
+.. autofunction:: get_named_range_as_dict
+
+.. autofunction:: const_params

--- a/doc/source/libraries/annuallife/TradLife_A_EX1/PolicyAttrs.rst
+++ b/doc/source/libraries/annuallife/TradLife_A_EX1/PolicyAttrs.rst
@@ -1,0 +1,10 @@
+The **PolicyAttrs** Space (TradLife_A_EX1)
+==========================================
+
+.. automodule:: annuallife.TradLife_A_EX1.PolicyAttrs
+
+
+Cells Descriptions
+------------------
+
+.. autofunction:: segment

--- a/doc/source/libraries/annuallife/TradLife_A_EX1/Projection.rst
+++ b/doc/source/libraries/annuallife/TradLife_A_EX1/Projection.rst
@@ -1,0 +1,14 @@
+The **Projection** Space (TradLife_A_EX1)
+=========================================
+
+.. automodule:: annuallife.TradLife_A_EX1.Projection
+
+
+Cells Descriptions
+------------------
+
+.. autofunction:: risk_life_sub
+
+.. autofunction:: risk_life
+
+.. autofunction:: risk_margin

--- a/doc/source/libraries/annuallife/index.rst
+++ b/doc/source/libraries/annuallife/index.rst
@@ -27,6 +27,22 @@ Cells for investment income reserves are defined but not implemented.
 
 See :mod:`~annuallife.TradLife_A` for more details.
 
+Nested projection example
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The library also packages :mod:`~annuallife.TradLife_A_EX1`, an example
+model that demonstrates how to build a **nested projection** in modelx —
+a projection that, at each step, runs further inner projections. The
+technique is illustrated with a Solvency II life-risk SCR and risk-margin
+calculation built on :mod:`~annuallife.TradLife_A`, but the focus is the
+nested-projection pattern rather than the Solvency II implementation
+itself.
+
+:mod:`~annuallife.TradLife_A_EX1` reuses the structure, assumptions and
+input data of :mod:`~annuallife.TradLife_A`; only the spaces that change
+are documented on its page. See :mod:`~annuallife.TradLife_A_EX1` for the
+list of updates from :mod:`~annuallife.TradLife_A`.
+
 Successor of simplelife
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -98,23 +114,29 @@ Library Contents
    :maxdepth: 1
 
    TradLife_A
+   TradLife_A_EX1
    tradlife_a-demo
    tradlife_a-space-overview
 
 .. table::
    :widths: 25 75
 
-   ====================================== ==========================================================================
-   File or Folder                         Description
-   ====================================== ==========================================================================
-   ``TradLife_A``                         The :mod:`~annuallife.TradLife_A` model.
-   ``TradLife_A_mx30``                    Copy of :mod:`~annuallife.TradLife_A` saved in the modelx serializer version 6 format, for ``modelx`` older than v0.31.0.
-   ``input.xlsx``                         Excel workbook holding policy data, assumptions, mortality tables, scenarios and product specs.
-   ``plot_tradlife_a.py``                 sphinx-gallery plot script that renders the cashflow chart.
-   ``plot_pvcashflows_tradlife_a.py``     sphinx-gallery plot script that renders present-value cashflows.
-   ``tradlife_a-demo.ipynb``              Jupyter notebook demonstrating cashflow projection.
-   ``tradlife_a-space-overview.ipynb``    Tutorial notebook on the space tree of :mod:`~annuallife.TradLife_A`.
-   ====================================== ==========================================================================
+   ============================================= ==========================================================================
+   File or Folder                                Description
+   ============================================= ==========================================================================
+   ``TradLife_A``                                The :mod:`~annuallife.TradLife_A` model.
+   ``TradLife_A_EX1``                            The :mod:`~annuallife.TradLife_A_EX1` model, a Solvency II life-risk extension of :mod:`~annuallife.TradLife_A`.
+   ``TradLife_A_mx30``                           Copy of :mod:`~annuallife.TradLife_A` saved in the modelx serializer version 6 format, for ``modelx`` older than v0.31.0.
+   ``input.xlsx``                                Excel workbook holding policy data, assumptions, mortality tables, scenarios and product specs. It also holds the ``LifeShocks``, ``LifeCorr`` and ``CoCRate`` inputs read by :mod:`~annuallife.TradLife_A_EX1`.
+   ``plot_tradlife_a.py``                        Python script for :doc:`/generated_examples/annuallife/plot_tradlife_a`
+   ``plot_pvcashflows_tradlife_a.py``            Python script for :doc:`/generated_examples/annuallife/plot_pvcashflows_tradlife_a`
+   ``plot_scr_cashflows_tradlife_a_ex1.py``      Python script for :doc:`/generated_examples/annuallife/plot_scr_cashflows_tradlife_a_ex1`
+   ``plot_scr_radar_tradlife_a_ex1.py``          Python script for :doc:`/generated_examples/annuallife/plot_scr_radar_tradlife_a_ex1`
+   ``plot_pols_if_lapse_up_tradlife_a_ex1.py``   Python script for :doc:`/generated_examples/annuallife/plot_pols_if_lapse_up_tradlife_a_ex1`
+   ``draw_charts_radar.py``                      Helper module providing ``draw_radar`` for the radar plot script.
+   ``tradlife_a-demo.ipynb``                     Jupyter notebook demonstrating cashflow projection.
+   ``tradlife_a-space-overview.ipynb``           Tutorial notebook on the space tree of :mod:`~annuallife.TradLife_A`.
+   ============================================= ==========================================================================
 
 
 Jupyter Notebooks

--- a/lifelib/libraries/annuallife/TradLife_A_EX1/Assumptions/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/Assumptions/__init__.py
@@ -5,181 +5,32 @@
 
 """Assumption input and calculations for individual policies.
 
-This Space holds assumption parameters and rates used by
-:mod:`~annuallife.TradLife_A.Projection` and its base spaces.
-
-The main role of this Space is to associate assumption data sourced
-from :mod:`~annuallife.TradLife_A.InputData` with the model points
-held in
-:func:`~annuallife.TradLife_A.InputData.policy_data`, and to expose
-the resulting per-policy values as 1-D :mod:`numpy` arrays whose
-layout matches the rows of ``policy_data``. Callers therefore index
-into them with the integer policy index ``idx``. A few cells, such
-as :func:`asmp_tables` and :func:`mortality_tables`, return tables
-shared across all policies.
-
-The association is carried out by chaining two helper cells inherited
-from the :mod:`~annuallife.TradLife_A.Utilities` base Space:
-
-* :func:`~annuallife.TradLife_A.Utilities.map_to_policies` reindexes
-  an assumption ``Series`` keyed by lookup columns (e.g. ``Product``,
-  ``PolType``, ``Gen``) onto the rows of ``policy_data``, so the
-  result has one entry per policy.
-* :func:`~annuallife.TradLife_A.Utilities.pandas_to_array` then
-  converts that ``Series`` (or a ``DataFrame``, for table-returning
-  cells) into a NumPy array when
-  :attr:`~annuallife.TradLife_A.Utilities.return_array` is ``True``
-  (the default). When ``return_array`` is ``False`` the pandas
-  object is passed through unchanged, which is convenient for
-  inspection and debugging.
-
-A typical per-policy Cells in this Space therefore implements the
-following pipeline:
-
-.. mermaid::
-
-    graph LR
-        A["input_data.assumption(key)<br/>pandas Series keyed by<br/>(Product, PolType, Gen)"]
-        --> B["map_to_policies<br/>reindex onto<br/>policy_data rows"]
-        B --> C["pandas_to_array<br/>convert when<br/>return_array=True"]
-        C --> D["1-D NumPy array<br/>indexed by policy idx"]
-
-For example, :func:`comm_init_prem` is implemented as
-``pandas_to_array(map_to_policies(input_data.assumption('CommInitPrem')))``,
-and most other per-policy cells in this Space follow the same
-pattern.
-
-The three steps can also be executed individually on a console,
-which is useful for inspecting the intermediate pandas objects::
-
-    >>> asmp = m.Assumptions
-
-    >>> # Step 1: raw assumption Series keyed by lookup columns
-    >>> s = asmp.input_data.assumption('CommInitPrem')
-    >>> s
-    Product
-    TERM    0.2
-    WL      0.5
-    ENDW    0.5
-    Name: CommInitPrem, dtype: float64
-
-    >>> # Step 2: reindex onto the rows of policy_data
-    >>> mapped = asmp.map_to_policies(s)
-    >>> mapped.head()
-    Policy
-    1    0.2
-    2    0.2
-    3    0.2
-    4    0.2
-    5    0.2
-    Name: CommInitPrem, dtype: float64
-    >>> len(mapped)
-    300
-
-    >>> # Step 3: convert to a 1-D NumPy array (return_array is True)
-    >>> asmp.pandas_to_array(mapped)
-    array([0.2, 0.2, 0.2, ..., 0.5, 0.5, 0.5])
-
-Composing the three calls is exactly what :func:`comm_init_prem`
-returns.
-
-Parameters and References
--------------------------
-
-Attributes:
-    input_data: Alias for :mod:`~annuallife.TradLife_A.InputData`.
-        Per-policy assumptions are read from the ``AssumptionTable``
-        range in *input.xlsx* via
-        :func:`~annuallife.TradLife_A.InputData.assumption`,
-        and mortality / lapse tables from
-        :func:`~annuallife.TradLife_A.InputData.assumption_tables` and
-        :func:`~annuallife.TradLife_A.InputData.mortality_tables`.
-
-.. rubric:: Inherited helpers
-
-Inherited from :mod:`~annuallife.TradLife_A.Utilities`:
-
-* :func:`~annuallife.TradLife_A.Utilities.pandas_to_array`
-* :func:`~annuallife.TradLife_A.Utilities.map_to_policies`
-* :attr:`~annuallife.TradLife_A.Utilities.return_array`
-
-.. rubric:: Child spaces
-
-* :mod:`~annuallife.TradLife_A.Assumptions.AsmpID`: Enum-style codes
-  identifying entries in the ``AsmpByDuration`` table.
-
+This Space is :mod:`TradLife_A.Assumptions <annuallife.TradLife_A.Assumptions>` with additional
+Cells that supply the Solvency II life-risk parameters. The per-policy
+assumption pipeline (``map_to_policies`` then ``pandas_to_array``) and
+all the existing assumption Cells are unchanged; see
+:mod:`TradLife_A.Assumptions <annuallife.TradLife_A.Assumptions>` for them.
 
 Cells Summary
 -------------
 
-Commission Assumptions
-^^^^^^^^^^^^^^^^^^^^^^
-
-Per-policy initial and renewal commission rates and the renewal
-commission term.
-
-.. autosummary::
-
-   ~comm_init_prem
-   ~comm_ren_prem
-   ~comm_ren_term
-
-
-Expense Assumptions
-^^^^^^^^^^^^^^^^^^^
-
-Per-policy acquisition and maintenance expense assumptions, expressed
-per annualized premium, per policy and per sum assured.
-
-.. autosummary::
-
-   ~exps_acq_ann_prem
-   ~exps_acq_pol
-   ~exps_acq_sa
-   ~exps_maint_ann_prem
-   ~exps_maint_pol
-   ~exps_maint_sa
-
-
-Tax and Inflation Assumptions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The consumption tax rate, the expense inflation rate and the
-cost-of-capital rate for the Solvency II risk margin.
-
-.. autosummary::
-
-   ~cnsmp_tax
-   ~inflation_rate
-   ~coc_rate
-
-
-Mortality
+New Cells
 ^^^^^^^^^
 
-The mortality-table block and the per-policy indices that select each
-policy's base mortality rates and its last mortality age.
+:func:`life_shock_param` forwards a life-shock factor from
+:func:`~annuallife.TradLife_A_EX1.InputData.life_shock_data`, keyed by the
+``(risk, shock, scope, extra_key)`` codes. :func:`life_corr` forwards a
+single life-risk correlation coefficient from
+:func:`~annuallife.TradLife_A_EX1.InputData.life_corr_data` as a native
+:obj:`float`. :func:`coc_rate` forwards the cost-of-capital rate
+(``CoCRate``) used by
+:func:`~annuallife.TradLife_A_EX1.Projection.risk_margin`.
 
 .. autosummary::
 
-   ~mortality_tables
-   ~mort_table_index
-   ~mort_array_index
-   ~last_mort_age
-
-
-Mortality Factor and Lapse
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The assumption-by-duration table and the per-policy indices that
-select mortality factors and lapse rates, together with its row count.
-
-.. autosummary::
-
-   ~asmp_tables
-   ~mort_factor_index
-   ~lapse_rate_index
-   ~asmp_table_len
+   ~life_shock_param
+   ~life_corr
+   ~coc_rate
 
 """
 
@@ -209,9 +60,9 @@ def coc_rate():
     """Cost-of-capital rate for the Solvency II risk margin.
 
     Forwards the ``CoCRate`` scalar from the ``ConstParams`` named range
-    (read by :func:`~annuallife.TradLife_A.InputData.const_params`) to the
+    (read by :func:`~annuallife.TradLife_A_EX1.InputData.const_params`) to the
     projection, where it is used by
-    :func:`~annuallife.TradLife_A.Projection.risk_margin`. The value is a
+    :func:`~annuallife.TradLife_A_EX1.Projection.risk_margin`. The value is a
     native :obj:`float` (e.g. ``0.06`` for 6%).
     """
     return input_data.const_params()['CoCRate']
@@ -284,7 +135,7 @@ def mort_table_index():
 
     Maps the ``BaseMort`` assumption keyed by the model point lookup
     (product, policy type, gen) to each row of
-    :func:`~annuallife.TradLife_A.InputData.policy_data`.
+    :func:`TradLife_A.InputData.policy_data <annuallife.TradLife_A.InputData.policy_data>`.
     """
     return map_to_policies(input_data.assumption('BaseMort'))
 
@@ -293,7 +144,7 @@ def mort_array_index():
     """Per-policy column index into :func:`mortality_tables`.
 
     Returns a 1-D integer array of column positions in
-    :func:`~annuallife.TradLife_A.InputData.mortality_tables` for each
+    :func:`TradLife_A.InputData.mortality_tables <annuallife.TradLife_A.InputData.mortality_tables>` for each
     policy's ``(mort_table_index, sex)`` pair.
     """
 
@@ -322,8 +173,8 @@ def asmp_tables():
 
     Returns the ``AsmpByDuration`` range from *input.xlsx* as a 2-D
     NumPy array indexed by duration (rows) and assumption ID (columns).
-    Used by :func:`~annuallife.TradLife_A.BaseProj.mort_factor` and
-    :func:`~annuallife.TradLife_A.BaseProj.lapse_rate` together with
+    Used by :func:`TradLife_A.BaseProj.mort_factor <annuallife.TradLife_A.BaseProj.mort_factor>` and
+    :func:`TradLife_A.BaseProj.lapse_rate <annuallife.TradLife_A.BaseProj.lapse_rate>` together with
     :func:`mort_factor_index` and :func:`lapse_rate_index`.
     """
     return pandas_to_array(input_data.assumption_tables())
@@ -333,7 +184,7 @@ def mort_factor_index():
     """Per-policy column index into :func:`asmp_tables` for mortality factors.
 
     Resolves each policy's ``MortFactor`` assumption (referencing an
-    :mod:`~annuallife.TradLife_A.Assumptions.AsmpID`) to its column
+    :mod:`TradLife_A.Assumptions.AsmpID <annuallife.TradLife_A.Assumptions.AsmpID>`) to its column
     position in the ``AsmpByDuration`` table.
     """
 
@@ -349,7 +200,7 @@ def lapse_rate_index():
     """Per-policy column index into :func:`asmp_tables` for lapse rates.
 
     Resolves each policy's ``Surrender`` assumption (referencing an
-    :mod:`~annuallife.TradLife_A.Assumptions.AsmpID`) to its column
+    :mod:`TradLife_A.Assumptions.AsmpID <annuallife.TradLife_A.Assumptions.AsmpID>`) to its column
     position in the ``AsmpByDuration`` table.
     """
 
@@ -367,6 +218,21 @@ def asmp_table_len():
 
 
 def life_shock_param(risk, shock=0, scope=0, extra_key=0):
+    """Life shock factor for the given risk / shock / scope / extra key.
+
+    Forwards a single value from
+    :func:`~annuallife.TradLife_A_EX1.InputData.life_shock_data`, the
+    ``LifeShocks`` input keyed by the ``(risk, shock, scope, extra_key)``
+    integer codes. Arguments left at their default ``0`` select the entry
+    with no shock / scope / extra qualifier.
+
+    Args:
+        risk: A ``LifeRiskID`` code for the life sub-risk.
+        shock: A ``LapseShockID`` code (lapse risk only); defaults to 0.
+        scope: A ``LapseScopeID`` code; defaults to 0.
+        extra_key: An ``ExtraKeyID`` code (e.g. ``LIMIT``, ``INFL``);
+            defaults to 0.
+    """
     return input_data.life_shock_data()[risk, shock, scope, extra_key]
 
 
@@ -374,17 +240,17 @@ def life_corr(risk_i, risk_j):
     """Correlation coefficient between two life underwriting sub-risks.
 
     Forwards a single coefficient from the correlation matrix read by
-    :func:`~annuallife.TradLife_A.InputData.life_corr_data`. The two
+    :func:`~annuallife.TradLife_A_EX1.InputData.life_corr_data`. The two
     risks are taken as integer parameters and a plain :obj:`float` is
     returned (rather than a :obj:`dict` or :class:`~pandas.DataFrame`) so
-    that the consuming :func:`~annuallife.TradLife_A.Projection.risk_life`
+    that the consuming :func:`~annuallife.TradLife_A_EX1.Projection.risk_life`
     cell stays on native scalar types, which matters when the projection
     is compiled with Cython.
 
     Args:
-        risk_i: A :class:`~annuallife.TradLife_A.Enums.LifeRiskID.LifeRiskID`
+        risk_i: A ``LifeRiskID``
             code for the first sub-risk.
-        risk_j: A :class:`~annuallife.TradLife_A.Enums.LifeRiskID.LifeRiskID`
+        risk_j: A ``LifeRiskID``
             code for the second sub-risk.
     """
     return float(input_data.life_corr_data().at[risk_i, risk_j])

--- a/lifelib/libraries/annuallife/TradLife_A_EX1/Enums/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/Enums/__init__.py
@@ -3,21 +3,26 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
-"""Enum-style codes used across :mod:`~annuallife.TradLife_A`.
+"""Enum-style codes used across :mod:`~annuallife.TradLife_A_EX1`.
 
-This Space groups the small integer-coded enumerations referenced by
-the projection cells. Each enum is exposed as a child Space whose
-References hold the integer codes for its members:
+This Space extends :mod:`TradLife_A.Enums <annuallife.TradLife_A.Enums>` with the
+enumerations used by the Solvency II life-risk calculations. The
+``ProductID``, ``SexID`` and ``RateBasisID`` enums are unchanged from
+:mod:`TradLife_A.Enums <annuallife.TradLife_A.Enums>`.
 
-* :mod:`~annuallife.TradLife_A.Enums.ProductID` - product type codes
-  (``TERM``, ``WL``, ``ENDW``).
-* :mod:`~annuallife.TradLife_A.Enums.SexID` - sex codes used to index
-  mortality tables (``M``, ``F``).
-* :mod:`~annuallife.TradLife_A.Enums.RateBasisID` - rate-basis codes
-  used by the commutation lookup (``PREM``, ``VAL``).
+.. rubric:: New enum child Spaces
 
-The three child spaces are also re-exported at the model level as
-``ProductID``, ``SexID`` and ``RateBasisID`` for convenience.
+The following enum child Spaces are added. Each exposes its members as
+integer References.
+
+* ``LifeRiskID`` -- life sub-risks: ``MORT``, ``LONGV``, ``DISAB``,
+  ``LAPSE``, ``EXPS``, ``REV`` and ``CAT``, plus ``BASE`` (0) for the
+  unstressed run.
+* ``LapseShockID`` -- lapse shocks: ``UP``, ``DOWN`` and ``MASS``.
+* ``LapseScopeID`` -- lapse scope: ``RETAIL`` and ``INST``.
+* ``ExtraKeyID`` -- extra qualifiers for shock parameters, such as
+  ``LIMIT`` (a cap on the shocked rate) and ``INFL`` (the
+  expense-inflation stress).
 
 """
 

--- a/lifelib/libraries/annuallife/TradLife_A_EX1/InputData/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/InputData/__init__.py
@@ -5,96 +5,42 @@
 
 """Input data loaded from *input.xlsx*.
 
-The :mod:`~annuallife.TradLife_A.InputData` Space contains Cells that
-load values from named ranges in the Excel input file, *input.xlsx*,
-and helper Cells that turn those ranges into pandas objects ready for
-the rest of the model.
-
-Per-policy attributes, assumption tables, scenarios, mortality tables
-and product specs are loaded on demand by the cells listed below. The
-workbook itself is opened lazily by :func:`input_workbook`.
-
-The table below lists the cells and the Excel named ranges they read.
-
-============================== =====================  ==========================================
- Cell                           Named range            Purpose
-============================== =====================  ==========================================
-:func:`policy_data`            ``PolicyData``         Per-policy attributes for model points.
-:func:`product_spec`           ``ProductSpecTable``   Per-product loading and rate tables.
-:func:`assumption`             ``AssumptionTable``    Lookup table of assumption keys.
-:func:`assumption_tables`      ``AsmpByDuration``     Duration-based mortality / lapse tables.
-:func:`mortality_tables`       ``MortalityTables``    Mortality tables keyed by Sex / Table.
-:func:`scenarios`              ``Scenarios``          Scenario interest-rate paths.
-:func:`discount_rate`          ``LargePolDiscount``   Premium discount by sum-assured band.
-:func:`prem_waiver_cost`       ``PremiumWaiverCost``  Premium-waiver cost lookup.
-:func:`const_params`           ``ConstParams``        Scalar parameters used across the model.
-============================== =====================  ==========================================
-
-Parameters and References
--------------------------
-
-Attributes:
-    input_file_name(:obj:`str`): Name of the Excel workbook to read.
-        Defaults to ``"input.xlsx"`` and is resolved relative to the
-        parent directory of the model.
-    openpyxl: The :mod:`openpyxl` module used to open the workbook.
-
+This Space is :mod:`TradLife_A.InputData <annuallife.TradLife_A.InputData>` with additional
+Cells that read the Solvency II life-shock and correlation inputs. The
+existing readers (policy data, assumptions, mortality tables, scenarios,
+product specs and scalar constants) are unchanged; see
+:mod:`TradLife_A.InputData <annuallife.TradLife_A.InputData>` for them.
 
 Cells Summary
 -------------
 
-Workbook
-^^^^^^^^
+New Cells
+^^^^^^^^^
 
-Opens the Excel input workbook lazily; every other cell reads from it.
-
-.. autosummary::
-
-   ~input_workbook
-
-
-Input Tables
-^^^^^^^^^^^^
-
-Named ranges loaded as pandas objects: policy data, mortality and
-assumption tables, scenarios, discount and premium-waiver lookups and
-the scalar constants.
+:func:`life_shock_data` reads the ``LifeShocks`` named range and returns
+a :obj:`dict` of shock factors keyed by ``(risk, shock, scope,
+extra_key)`` integer codes. :func:`life_corr_data` reads the ``LifeCorr``
+named range and returns the life-risk correlation matrix as a
+:class:`~pandas.DataFrame` indexed on both axes by ``LifeRiskID`` codes.
 
 .. autosummary::
 
-   ~policy_data
-   ~mortality_tables
-   ~mort_table_last_ages
-   ~assumption_tables
-   ~scenarios
-   ~discount_rate
-   ~prem_waiver_cost
-   ~const_params
+   ~life_shock_data
+   ~life_corr_data
 
+Updated Cells
+^^^^^^^^^^^^^
 
-Lookups
-^^^^^^^
-
-Column lookups into the assumption and product-specification tables,
-keyed by the model point lookup levels.
+:func:`get_named_range_as_dict` is generalised to support named ranges
+with more than two columns: the right-most column holds the values and
+the remaining columns form a tuple key (used by :func:`life_shock_data`).
+:func:`const_params` now also exposes the new ``CoCRate``
+(cost-of-capital) parameter read from the ``ConstParams`` range.
 
 .. autosummary::
 
-   ~assumption
-   ~product_spec
-
-
-Helpers
-^^^^^^^
-
-Generic readers that turn a named range into a ``DataFrame``, a
-``dict`` or a keyed ``Series``.
-
-.. autosummary::
-
-   ~get_named_range_as_df
    ~get_named_range_as_dict
-   ~get_param_series
+   ~const_params
 
 """
 
@@ -340,6 +286,15 @@ def const_params():
 
 
 def life_shock_data():
+    """Life shock factors from the ``LifeShocks`` named range.
+
+    Returns a :obj:`dict` of shock factors keyed by
+    ``(risk, shock, scope, extra_key)``. The enum-name strings in the
+    input (e.g. ``MORT``, ``UP``, ``LIMIT``) are converted to the
+    corresponding integer codes of :mod:`~annuallife.TradLife_A_EX1.Enums`,
+    and a blank qualifier maps to ``0``. Consumed per key by
+    :func:`~annuallife.TradLife_A_EX1.Assumptions.life_shock_param`.
+    """
 
     d = get_named_range_as_dict('LifeShocks')
 
@@ -356,6 +311,13 @@ def life_shock_data():
 
 
 def life_corr_data():
+    """Life-risk correlation matrix from the ``LifeCorr`` named range.
+
+    Returns a square :class:`~pandas.DataFrame` whose row and column
+    labels are ``LifeRiskID`` integer codes (the enum-name headers in the
+    input are converted to codes). Consumed by
+    :func:`~annuallife.TradLife_A_EX1.Assumptions.life_corr`.
+    """
     df = get_named_range_as_df('LifeCorr', index_len=1)
     df.columns = [getattr(LifeRiskID, c) for c in df.columns]
     df.index = [getattr(LifeRiskID, r) for r in df.index]

--- a/lifelib/libraries/annuallife/TradLife_A_EX1/PolicyAttrs/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/PolicyAttrs/__init__.py
@@ -5,221 +5,24 @@
 
 """Policy attributes and policy values.
 
-This Space holds policy attributes and policy-level values used by
-:mod:`~annuallife.TradLife_A.Projection` and its base spaces.
-
-The main role of this Space is to associate product specs sourced
-from :mod:`~annuallife.TradLife_A.InputData` with the model points
-held in
-:func:`~annuallife.TradLife_A.InputData.policy_data`, and to expose
-the resulting per-policy values as 1-D :mod:`numpy` arrays whose
-layout matches the rows of ``policy_data``. Callers therefore index
-into them with the integer policy index ``idx``.
-
-The Cells fall into two groups by their data source:
-
-* **Model point attributes**, such as :func:`product`,
-  :func:`issue_age` and :func:`sum_assured`, read a column directly
-  from :func:`~annuallife.TradLife_A.InputData.policy_data` and
-  convert it to a NumPy array.
-* **Product-level values**, such as :func:`int_rate`,
-  :func:`table_id` and :func:`load_acq_sa_param1`, look up a column
-  in :func:`~annuallife.TradLife_A.InputData.product_spec` keyed by
-  product attributes (e.g. ``Product``, ``PolType``, ``Gen``) and
-  reindex it onto the rows of ``policy_data`` before converting it
-  to a NumPy array. These Cells are typically used to build the
-  loadings and rates consumed by
-  :func:`~annuallife.TradLife_A.BaseProj.gross_prem_rate`.
-
-Both groups end with the same array-conversion step. The reindexing
-and conversion are performed by helper Cells inherited from the
-:mod:`~annuallife.TradLife_A.Utilities` base Space:
-
-* :func:`~annuallife.TradLife_A.Utilities.map_to_policies` reindexes
-  a ``Series`` keyed by lookup columns onto the rows of
-  ``policy_data``, so the result has one entry per policy.
-* :func:`~annuallife.TradLife_A.Utilities.pandas_to_array` then
-  converts that ``Series`` into a NumPy array when
-  :attr:`~annuallife.TradLife_A.Utilities.return_array` is ``True``
-  (the default). When ``return_array`` is ``False`` the pandas
-  object is passed through unchanged, which is convenient for
-  inspection and debugging.
-
-The two pipelines are illustrated below:
-
-.. mermaid::
-
-    graph LR
-        A1["policy_data()['col']<br/>pandas Series<br/>indexed by Policy"]
-        A2["product_spec(name)<br/>pandas Series keyed by<br/>(Product, PolType, Gen)"]
-        A2 --> B["map_to_policies<br/>reindex onto<br/>policy_data rows"]
-        A1 --> C["pandas_to_array<br/>convert when<br/>return_array=True"]
-        B --> C
-        C --> D["1-D NumPy array<br/>indexed by policy idx"]
-
-For example, :func:`issue_age` is implemented as
-``pandas_to_array(input_data.policy_data()['IssueAge'])`` (top
-branch), while :func:`load_acq_sa_param1` is implemented as
-``pandas_to_array(map_to_policies(input_data.product_spec('LoadAcqSAParam1')))``
-(bottom branch).
-
-The steps can also be executed individually on a console, which is
-useful for inspecting the intermediate pandas objects::
-
-    >>> pol = m.PolicyAttrs
-
-    >>> # Model-point attribute: pick a column from policy_data
-    >>> s = pol.input_data.policy_data()['IssueAge']
-    >>> s.head()
-    Policy
-    1    30
-    2    30
-    3    31
-    4    31
-    5    32
-    Name: IssueAge, dtype: int64
-    >>> len(s)
-    300
-
-    >>> # Convert to a 1-D NumPy array (return_array is True)
-    >>> pol.pandas_to_array(s)
-    array([30, 30, 31, ..., 78, 79, 79])
-
-    >>> # Product-level value: look up a column in product_spec
-    >>> ps = pol.input_data.product_spec('LoadAcqSAParam1')
-    >>> ps
-    Product
-    TERM    0.00
-    WL      0.02
-    ENDW    0.02
-    Name: LoadAcqSAParam1, dtype: float64
-
-    >>> # Reindex onto the rows of policy_data
-    >>> mapped = pol.map_to_policies(ps)
-    >>> mapped.head()
-    Policy
-    1    0.0
-    2    0.0
-    3    0.0
-    4    0.0
-    5    0.0
-    Name: LoadAcqSAParam1, dtype: float64
-    >>> len(mapped)
-    300
-
-    >>> # Convert to a 1-D NumPy array
-    >>> pol.pandas_to_array(mapped)
-    array([0.  , 0.  , 0.  , ..., 0.02, 0.02, 0.02])
-
-Composing these calls is exactly what :func:`issue_age` and
-:func:`load_acq_sa_param1` return.
-
-Parameters and References
--------------------------
-
-Attributes:
-    input_data: Alias for :mod:`~annuallife.TradLife_A.InputData`.
-        Per-policy attributes are read from the ``PolicyData`` range
-        in *input.xlsx* via
-        :func:`~annuallife.TradLife_A.InputData.policy_data`,
-        and product specs from
-        :func:`~annuallife.TradLife_A.InputData.product_spec`.
-    prem_term: Alias for :func:`policy_term`.
-
-.. rubric:: Inherited helpers
-
-Inherited from :mod:`~annuallife.TradLife_A.Utilities`:
-
-* :func:`~annuallife.TradLife_A.Utilities.pandas_to_array`
-* :func:`~annuallife.TradLife_A.Utilities.map_to_policies`
-* :attr:`~annuallife.TradLife_A.Utilities.return_array`
-
+This Space is :mod:`TradLife_A.PolicyAttrs <annuallife.TradLife_A.PolicyAttrs>` with one addition
+for the Solvency II lapse stress; all other Cells are unchanged, see
+:mod:`TradLife_A.PolicyAttrs <annuallife.TradLife_A.PolicyAttrs>`.
 
 Cells Summary
 -------------
 
-Policy Attributes
-^^^^^^^^^^^^^^^^^
+New Cells
+^^^^^^^^^
 
-Model point attributes read directly from
-:func:`~annuallife.TradLife_A.InputData.policy_data` for each policy.
-
-.. autosummary::
-
-   ~product
-   ~policy_type
-   ~sex
-   ~issue_age
-   ~prem_freq
-   ~policy_term
-   ~policy_count
-   ~sum_assured
-   ~gen
-   ~channel
-   ~duration
-
-
-Product Bases
-^^^^^^^^^^^^^
-
-Per-policy interest rate and mortality table identifiers, selected by
-rate basis (premium or valuation).
+:func:`segment` returns the per-policy lapse-risk segment as a
+``LapseScopeID`` code (currently ``RETAIL`` for every policy). It selects
+the mass-lapse factor applied by
+:func:`~annuallife.TradLife_A_EX1.Projection.InnerProj.pols_lapse_mass`.
 
 .. autosummary::
 
-   ~int_rate
-   ~table_id
-
-
-Loadings
-^^^^^^^^
-
-Per-policy acquisition and maintenance loadings used by
-:func:`~annuallife.TradLife_A.BaseProj.gross_prem_rate`, together with
-the raw ``ProductSpecTable`` parameters they are built from.
-
-.. autosummary::
-
-   ~load_acq_sa
-   ~load_acq_sa_param1
-   ~load_acq_sa_param2
-   ~load_maint_prem
-   ~load_maint_prem_param1
-   ~load_maint_prem_param2
-   ~load_maint_prem_waiver_prem
-   ~load_maint_sa
-   ~load_maint_sa2
-
-
-Surrender Charges
-^^^^^^^^^^^^^^^^^
-
-The per-policy initial surrender charge rate and the raw
-``ProductSpecTable`` parameters it is built from.
-
-.. autosummary::
-
-   ~init_surr_charge
-   ~surr_charge_param1
-   ~surr_charge_param2
-
-
-Misc
-^^^^
-
-Placeholder cells reserved for future use.
-
-.. warning::
-
-   :func:`gross_prem_table`, :func:`reserve_rate` and
-   :func:`uern_prem_rate` are placeholders that currently return
-   ``None`` and are to be implemented.
-
-.. autosummary::
-
-   ~gross_prem_table
-   ~reserve_rate
-   ~uern_prem_rate
+   ~segment
 
 """
 
@@ -332,12 +135,12 @@ def uern_prem_rate():
 
 
 def product():
-    """Per-policy product type as a :mod:`~annuallife.TradLife_A.Enums.ProductID` code."""
+    """Per-policy product type as a :mod:`TradLife_A.Enums.ProductID <annuallife.TradLife_A.Enums.ProductID>` code."""
     return pandas_to_array(input_data.policy_data()['Product'].map(lambda s: getattr(ProductID, s)))
 
 
 def policy_type():
-    """Per-policy policy type from the ``PolType`` column of :func:`~annuallife.TradLife_A.InputData.policy_data`."""
+    """Per-policy policy type from the ``PolType`` column of :func:`TradLife_A.InputData.policy_data <annuallife.TradLife_A.InputData.policy_data>`."""
     return pandas_to_array(input_data.policy_data()['PolType'])
 
 
@@ -352,7 +155,7 @@ def channel():
 
 
 def sex():
-    """Per-policy sex as a :mod:`~annuallife.TradLife_A.Enums.SexID` code."""
+    """Per-policy sex as a :mod:`TradLife_A.Enums.SexID <annuallife.TradLife_A.Enums.SexID>` code."""
     return pandas_to_array(input_data.policy_data()['Sex'].map(lambda s: getattr(SexID, s)))
 
 
@@ -423,6 +226,13 @@ def surr_charge_param2():
 
 
 def segment():
+    """Per-policy lapse-risk segment as a ``LapseScopeID`` code.
+
+    Returns a 1-D array, one entry per policy, giving the lapse-risk
+    segment that selects the mass-lapse factor applied by
+    :func:`~annuallife.TradLife_A_EX1.Projection.InnerProj.pols_lapse_mass`.
+    Every policy is currently assigned ``LapseScopeID.RETAIL``.
+    """
     return pandas_to_array(pd.Series(LapseScopeID.RETAIL, index=input_data.policy_data().index))
 
 

--- a/lifelib/libraries/annuallife/TradLife_A_EX1/Projection/InnerProj/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/Projection/InnerProj/__init__.py
@@ -3,6 +3,63 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
+"""Inner projection that re-runs the cashflows under a single life stress.
+
+This Space is the engine behind the Solvency II life-risk results in
+:mod:`~annuallife.TradLife_A_EX1.Projection`. Each ItemSpace
+``InnerProj[t0, risk, shock]`` re-runs the per-policy projection from the
+valuation time ``t0`` under one prescribed life stress, so that the
+stressed present value of net cashflows can be compared with the
+unstressed (baseline) one by
+:func:`~annuallife.TradLife_A_EX1.Projection.risk_life_sub`.
+
+It inherits all cashflow and present-value Cells from
+:mod:`TradLife_A.BaseProj <annuallife.TradLife_A.BaseProj>` and
+:mod:`TradLife_A.PV <annuallife.TradLife_A.PV>`, and overrides only the Cells needed to
+anchor the projection at ``t0`` and to apply the stress. The unstressed
+mortality, lapse and renewal-commission rates are taken from the outer
+projection and scaled by the shock; the acquisition and maintenance
+expenses are recomputed locally so they pick up the stressed
+:func:`inflation_factor`.
+
+Parameters and References
+-------------------------
+
+Attributes:
+    t0(:obj:`int`): Valuation time the inner projection is anchored at;
+        at ``t0`` the in-force equals that of the outer projection.
+    risk(:obj:`int`, optional): A ``LifeRiskID`` code selecting the life
+        sub-risk to stress. Defaults to ``BASE`` (0), the unstressed run.
+    shock(:obj:`int`, optional): A ``LapseShockID`` code selecting the
+        lapse shock (``UP``, ``DOWN`` or ``MASS``) when ``risk`` is
+        ``LAPSE``. Defaults to 0.
+
+Cells Summary
+-------------
+
+Overridden Cells
+^^^^^^^^^^^^^^^^
+
+The following Cells override their
+:mod:`TradLife_A.BaseProj <annuallife.TradLife_A.BaseProj>` counterparts to anchor the
+projection at ``t0`` and to apply the life shocks.
+
+.. autosummary::
+
+   ~pols_if
+   ~pols_if_beg1
+   ~pols_lapse_mass
+   ~claims_surr
+   ~claims_surr_mass_pp
+   ~mort_rate
+   ~lapse_rate
+   ~expense_acq_pp
+   ~expense_maint_pp
+   ~commissions_ren_pp
+   ~inflation_factor
+
+"""
+
 from modelx.serialize.jsonvalues import *
 
 _formula = lambda t0, risk=0, shock=0: None
@@ -25,7 +82,7 @@ def pols_if(t):
     The inner projection is anchored at the valuation time ``t0`` (where
     this returns the outer projection's in-force) and is defined only for
     ``t >= t0``. Present values are taken at ``t0`` (e.g.
-    :func:`~annuallife.TradLife_A.PV.pv_net_cf` at ``t0``), so the
+    :func:`TradLife_A.PV.pv_net_cf <annuallife.TradLife_A.PV.pv_net_cf>` at ``t0``), so the
     ``t < t0`` region is never reached in normal use; evaluating any
     in-force cell there would recurse without terminating.
     """
@@ -42,7 +99,7 @@ def pols_lapse_mass(t):
     the valuation time ``t0`` rather than an elevated surrender rate
     spread over the year. At ``t == t0`` a segment-dependent fraction
     (the ``LAPSE`` / ``MASS`` factor from the ``LifeShocks`` input,
-    selected by :func:`~annuallife.TradLife_A.PolicyAttrs.segment`) of
+    selected by :func:`~annuallife.TradLife_A_EX1.PolicyAttrs.segment`) of
     the policies in force at the beginning of the period instantly
     surrenders. The amount is removed from :func:`pols_if_beg1` so those
     policies neither pay premiums nor are exposed to mortality or ongoing
@@ -77,11 +134,11 @@ def claims_surr_mass_pp(t):
     """Surrender benefit per policy for the instantaneous mass-lapse surrenders.
 
     The ongoing surrenders are assumed to occur throughout the period, so
-    :func:`~annuallife.TradLife_A.BaseProj.claims_surr_pp` pays the
+    :func:`TradLife_A.BaseProj.claims_surr_pp <annuallife.TradLife_A.BaseProj.claims_surr_pp>` pays the
     mid-period average of the cash value at ``t`` and ``t+1``. The
     mass-lapse surrenders, by contrast, occur instantaneously at the
     valuation time, so the benefit is the cash value at time ``t`` only
-    (:func:`~annuallife.TradLife_A.BaseProj.cash_value_rate` at ``t``).
+    (:func:`TradLife_A.BaseProj.cash_value_rate <annuallife.TradLife_A.BaseProj.cash_value_rate>` at ``t``).
     """
     return sum_assured(t) * cash_value_rate(t)
 
@@ -93,7 +150,7 @@ def claims_surr(t):
     ongoing surrenders (:func:`pols_lapse`) and the instantaneous
     mass-lapse surrenders (:func:`pols_lapse_mass`). The ongoing
     surrenders receive the mid-period average cash value
-    (:func:`~annuallife.TradLife_A.BaseProj.claims_surr_pp`), while the
+    (:func:`TradLife_A.BaseProj.claims_surr_pp <annuallife.TradLife_A.BaseProj.claims_surr_pp>`), while the
     mass-lapse surrenders receive the cash value at time ``t``
     (:func:`claims_surr_mass_pp`).
     """
@@ -105,7 +162,7 @@ def lapse_rate(t):
     """Surrender Rate
 
     The unstressed rate is taken from the outer projection
-    (:func:`~annuallife.TradLife_A.BaseProj.lapse_rate`); the lapse-up /
+    (:func:`TradLife_A.BaseProj.lapse_rate <annuallife.TradLife_A.BaseProj.lapse_rate>`); the lapse-up /
     lapse-down shocks scale it (capped by the ``LIMIT`` factor), while the
     mass-lapse shock leaves the ongoing rate unchanged (it is modelled by
     :func:`pols_lapse_mass` instead).
@@ -139,10 +196,10 @@ def mort_rate(x):
     """Mortality rate at age ``x`` with the mortality / longevity shock applied.
 
     The unstressed rate is taken from the outer projection
-    (:func:`~annuallife.TradLife_A.BaseProj.mort_rate`). Under the
+    (:func:`TradLife_A.BaseProj.mort_rate <annuallife.TradLife_A.BaseProj.mort_rate>`). Under the
     ``MORT`` risk it is increased and under the ``LONGV`` risk it is
     decreased, by the factor read from the ``LifeShocks`` input via
-    :func:`~annuallife.TradLife_A.Assumptions.life_shock_param`. For any
+    :func:`~annuallife.TradLife_A_EX1.Assumptions.life_shock_param`. For any
     other risk the unstressed rate is returned unchanged.
     """
     base = _space._parent._parent.mort_rate(x)
@@ -161,11 +218,11 @@ def expense_acq_pp(t):
     """Acquisition expense per policy with the expense shock applied.
 
     Recomputes the acquisition expense locally (mirroring
-    :func:`~annuallife.TradLife_A.BaseProj.expense_acq_pp`) so it uses
+    :func:`TradLife_A.BaseProj.expense_acq_pp <annuallife.TradLife_A.BaseProj.expense_acq_pp>`) so it uses
     this Space's stressed :func:`inflation_factor`, then under the
     ``EXPS`` risk increases it by the factor read from the ``LifeShocks``
     input via
-    :func:`~annuallife.TradLife_A.Assumptions.life_shock_param`. For any
+    :func:`~annuallife.TradLife_A_EX1.Assumptions.life_shock_param`. For any
     other risk the unstressed amount is returned.
     """
     if t == 0:
@@ -186,11 +243,11 @@ def expense_maint_pp(t):
     """Maintenance expense per policy with the expense shock applied.
 
     Recomputes the maintenance expense locally (mirroring
-    :func:`~annuallife.TradLife_A.BaseProj.expense_maint_pp`) so it uses
+    :func:`TradLife_A.BaseProj.expense_maint_pp <annuallife.TradLife_A.BaseProj.expense_maint_pp>`) so it uses
     this Space's stressed :func:`inflation_factor`, then under the
     ``EXPS`` risk increases it by the factor read from the ``LifeShocks``
     input via
-    :func:`~annuallife.TradLife_A.Assumptions.life_shock_param`. For any
+    :func:`~annuallife.TradLife_A_EX1.Assumptions.life_shock_param`. For any
     other risk the unstressed amount is returned.
     """
     base = (ann_prem_pp(t) * asmp.exps_maint_ann_prem()[idx]
@@ -208,10 +265,10 @@ def commissions_ren_pp(t):
     """Renewal commission per policy with the expense shock applied.
 
     The unstressed renewal commission is taken from the outer projection
-    (:func:`~annuallife.TradLife_A.BaseProj.commissions_ren_pp`); under
+    (:func:`TradLife_A.BaseProj.commissions_ren_pp <annuallife.TradLife_A.BaseProj.commissions_ren_pp>`); under
     the ``EXPS`` risk it is increased by the factor read from the
     ``LifeShocks`` input via
-    :func:`~annuallife.TradLife_A.Assumptions.life_shock_param`. For any
+    :func:`~annuallife.TradLife_A_EX1.Assumptions.life_shock_param`. For any
     other risk the unstressed amount is returned unchanged.
     """
     base = _space._parent._parent.commissions_ren_pp(t)
@@ -226,10 +283,10 @@ def commissions_ren_pp(t):
 def inflation_factor(t):
     """Expense inflation factor with the expense-inflation shock applied.
 
-    Overrides :func:`~annuallife.TradLife_A.BaseProj.inflation_factor` to
+    Overrides :func:`TradLife_A.BaseProj.inflation_factor <annuallife.TradLife_A.BaseProj.inflation_factor>` to
     compound at a stressed inflation rate under the ``EXPS`` risk: the
     base rate plus the ``INFL`` factor read from the ``LifeShocks`` input
-    via :func:`~annuallife.TradLife_A.Assumptions.life_shock_param` (a +1
+    via :func:`~annuallife.TradLife_A_EX1.Assumptions.life_shock_param` (a +1
     percentage-point stress). The locally recomputed expenses
     (:func:`expense_maint_pp`, :func:`expense_acq_pp`) therefore inflate
     faster. For any other risk it equals the unstressed factor.

--- a/lifelib/libraries/annuallife/TradLife_A_EX1/Projection/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/Projection/__init__.py
@@ -3,65 +3,41 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
-"""Per-policy cashflow projection and present values for one model point and scenario.
+"""Per-policy projection, present values and Solvency II life-risk results.
 
-This is the user-facing Space of :mod:`~annuallife.TradLife_A`: each
-ItemSpace ``Projection[idx, scen_id]`` projects the cashflows and
-their present values for one policy under one scenario.
+This Space is :mod:`TradLife_A.Projection <annuallife.TradLife_A.Projection>` with the Solvency
+II life-risk outputs added and a new inner projection child Space. The
+parameters (``idx``, ``scen_id``), the inherited cashflow Cells (from
+:mod:`TradLife_A.BaseProj <annuallife.TradLife_A.BaseProj>`) and present-value Cells (from
+:mod:`TradLife_A.PV <annuallife.TradLife_A.PV>`) are unchanged; see
+:mod:`TradLife_A.Projection <annuallife.TradLife_A.Projection>`.
 
-.. rubric:: Inheritance Structure
+.. rubric:: New child Space
 
-The ``Projection`` Space inherits its contents from its base Spaces,
-:mod:`~annuallife.TradLife_A.BaseProj` and
-:mod:`~annuallife.TradLife_A.PV`.
-The projection cells are inherited from
-:mod:`~annuallife.TradLife_A.BaseProj`, and the present values of those
-cashflow items are inherited from :mod:`~annuallife.TradLife_A.PV`.
+:mod:`~annuallife.TradLife_A_EX1.Projection.InnerProj` re-runs the
+cashflows under a single prescribed life stress, anchored at a valuation
+time ``t0``.
 
-.. rubric:: Cells
+Cells Summary
+-------------
 
-In addition to the inherited cashflow and present-value Cells, this
-Space defines the Solvency II life underwriting capital requirements.
-:func:`risk_life_sub` returns the requirement for each individual life
-sub-risk — the baseline less the stressed present value of
-:func:`~annuallife.TradLife_A.PV.pv_net_cf` from the inner projection
-:mod:`~annuallife.TradLife_A.Projection.InnerProj`, floored at zero —
-and :func:`risk_life` aggregates them with the life-risk correlation
-matrix supplied by
-:func:`~annuallife.TradLife_A.Assumptions.life_corr`. They mirror
-``SCR_life.Life`` and ``SCR_life.SCR_life`` in the ``solvency2``
-library. Building on these, :func:`risk_margin` is the Solvency II risk
-margin: the cost-of-capital rate
-:func:`~annuallife.TradLife_A.Assumptions.coc_rate` applied to the
-projected :func:`risk_life` and discounted to ``t``.
+New Cells
+^^^^^^^^^
 
-Parameters and References
--------------------------
+:func:`risk_life_sub` is the capital requirement for a single life
+sub-risk -- the loss in :func:`TradLife_A.PV.pv_net_cf <annuallife.TradLife_A.PV.pv_net_cf>` under
+the stress, floored at zero. :func:`risk_life` aggregates the sub-risks
+with the correlation matrix from
+:func:`~annuallife.TradLife_A_EX1.Assumptions.life_corr`.
+:func:`risk_margin` is the Solvency II risk margin: the cost-of-capital
+rate :func:`~annuallife.TradLife_A_EX1.Assumptions.coc_rate` applied to
+the projected :func:`risk_life`, discounted to ``t``.
 
-This Space is parameterized with ``idx`` and ``scen_id``::
+.. autosummary::
 
-    >>> m.Projection.parameters
-    ('idx', 'scen_id')
-
-Calling this Space with a pair of integers returns the ItemSpace for
-the policy index and scenario ID. ``scen_id`` has a default value of 1,
-so for example ``Projection[0]`` represents the Projection Space for
-the first policy under scenario 1.
-
-Attributes:
-    idx(:obj:`int`): 0-based policy index into the policy data array.
-    scen_id(:obj:`int`, optional): Scenario ID, defaults to 1.
-
-.. rubric:: References
-
-The following references are inherited from
-:mod:`~annuallife.TradLife_A.BaseProj`:
-
-Attributes:
-    pol: Alias for :mod:`~annuallife.TradLife_A.PolicyAttrs`.
-    asmp: Alias for :mod:`~annuallife.TradLife_A.Assumptions`.
-    scen: Alias for :mod:`~annuallife.TradLife_A.Economic`.
-    comm_table: Alias for :mod:`~annuallife.TradLife_A.CommTable`.
+   ~risk_life_sub
+   ~risk_life
+   ~risk_margin
 
 """
 
@@ -98,7 +74,7 @@ def risk_life_sub(t, risk):
         - \mathrm{pv\_net\_cf}_{risk}(t),\; 0\right)
 
     Both present values are taken at the valuation time ``t`` from the
-    inner projection :mod:`~annuallife.TradLife_A.Projection.InnerProj`,
+    inner projection :mod:`~annuallife.TradLife_A_EX1.Projection.InnerProj`,
     which is anchored at ``t``. ``InnerProj[t]`` is the unstressed
     (baseline) run, while ``InnerProj[t, risk]`` applies the life shock
     selected by ``risk``. For the lapse risk the requirement is the worst
@@ -109,20 +85,20 @@ def risk_life_sub(t, risk):
 
     This mirrors ``SCR_life.Life`` (and, for the lapse shocks,
     ``SCR_life.LapseRisk``) in the ``solvency2`` library, with
-    :func:`~annuallife.TradLife_A.PV.pv_net_cf` standing in for the net
+    :func:`TradLife_A.PV.pv_net_cf <annuallife.TradLife_A.PV.pv_net_cf>` standing in for the net
     asset value.
 
     Args:
         t: Valuation time at which the inner projection is anchored.
-        risk: A :class:`~annuallife.TradLife_A.Enums.LifeRiskID.LifeRiskID`
+        risk: A ``LifeRiskID``
             value selecting the life sub-risk (e.g. ``MORT``, ``LONGV``,
             ``LAPSE``, ``EXPS``).
 
     .. seealso::
 
         * :func:`risk_life`
-        * :func:`~annuallife.TradLife_A.PV.pv_net_cf`
-        * :mod:`~annuallife.TradLife_A.Projection.InnerProj`
+        * :func:`TradLife_A.PV.pv_net_cf <annuallife.TradLife_A.PV.pv_net_cf>`
+        * :mod:`~annuallife.TradLife_A_EX1.Projection.InnerProj`
     """
     base_pv = InnerProj[t].pv_net_cf(t)
 
@@ -151,13 +127,13 @@ def risk_life(t):
     where ``i`` and ``j`` range over the life sub-risks and
     :math:`Corr_{i,j}` is the correlation coefficient between them,
     supplied per pair by
-    :func:`~annuallife.TradLife_A.Assumptions.life_corr`.
+    :func:`~annuallife.TradLife_A_EX1.Assumptions.life_corr`.
 
     This mirrors ``SCR_life.SCR_life`` in the ``solvency2`` library,
     parameterized by the valuation time ``t``. The aggregation is kept on
     native scalar types (a tuple of integer risk codes, with
     :func:`risk_life_sub` and
-    :func:`~annuallife.TradLife_A.Assumptions.life_corr` returning
+    :func:`~annuallife.TradLife_A_EX1.Assumptions.life_corr` returning
     :obj:`float`) so the Space stays efficient when compiled with Cython.
 
     Args:
@@ -166,7 +142,7 @@ def risk_life(t):
     .. seealso::
 
         * :func:`risk_life_sub`
-        * :func:`~annuallife.TradLife_A.Assumptions.life_corr`
+        * :func:`~annuallife.TradLife_A_EX1.Assumptions.life_corr`
     """
     risks = (LifeRiskID.MORT, LifeRiskID.LONGV, LifeRiskID.DISAB,
              LifeRiskID.LAPSE, LifeRiskID.EXPS, LifeRiskID.REV,
@@ -181,7 +157,7 @@ def risk_margin(t):
     The risk margin is the cost of holding the future life underwriting
     capital over the run-off of the in-force business: the
     cost-of-capital rate
-    :func:`~annuallife.TradLife_A.Assumptions.coc_rate` applied to each
+    :func:`~annuallife.TradLife_A_EX1.Assumptions.coc_rate` applied to each
     future aggregated life SCR :func:`risk_life`, discounted to ``t``.
 
     .. math::
@@ -204,7 +180,7 @@ def risk_margin(t):
         {1 + \mathrm{disc\_rate\_mth}(t)}
 
     which terminates at ``0`` once ``t`` is beyond
-    :func:`~annuallife.TradLife_A.BaseProj.proj_len`. At ``t = 0`` it is
+    :func:`TradLife_A.BaseProj.proj_len <annuallife.TradLife_A.BaseProj.proj_len>`. At ``t = 0`` it is
     the risk margin at the valuation date.
 
     Args:
@@ -213,7 +189,7 @@ def risk_margin(t):
     .. seealso::
 
         * :func:`risk_life`
-        * :func:`~annuallife.TradLife_A.Assumptions.coc_rate`
+        * :func:`~annuallife.TradLife_A_EX1.Assumptions.coc_rate`
     """
     if t > proj_len():
         return 0

--- a/lifelib/libraries/annuallife/TradLife_A_EX1/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/__init__.py
@@ -3,142 +3,232 @@
 # It can be imported as a Python module, but functions defined herein
 # are model formulas and may not be executable as standard Python.
 
-"""Annual new business projection model of basic traditional life policies.
+"""Example of a nested projection model, illustrated with a Solvency II life-risk SCR and risk margin.
 
 Overview
 --------
 
-:mod:`~annuallife.TradLife_A` is an annual new business projection model
-of basic traditional life policies, covering term, whole life and
-endowment products, built with
-`modelx <https://modelx.io/>`__.
+The purpose of :mod:`~annuallife.TradLife_A_EX1` is to demonstrate how to
+build a **nested projection** in modelx — a projection that, at each
+step, runs further *inner* projections. It is not intended as a complete
+Solvency II model; the Solvency II life-risk SCR and risk margin are used
+only as a concrete example to motivate the nested projection.
 
-It projects liability cashflows and their present values for policies
-represented by model points. Projected items include:
+The model extends :mod:`~annuallife.TradLife_A`. At a valuation time
+``t0`` it re-runs the per-policy cashflow projection under each
+prescribed life stress (the *inner* projections) and compares the
+stressed and unstressed present values of net cashflows to obtain:
 
-* Premiums,
-* Commissions and expenses,
-* Claims.
+* the capital requirement for each life sub-risk (mortality, longevity,
+  lapse and expense),
+* the aggregated life underwriting SCR, and
+* the risk margin.
 
-Premiums are calculated using commutation functions. Cells for investment
-income reserves are defined but not implemented.
+The inner projections are carried out by a new Space,
+:mod:`~annuallife.TradLife_A_EX1.Projection.InnerProj`, nested under
+:mod:`~annuallife.TradLife_A_EX1.Projection` and anchored at the
+valuation time ``t0``.
 
-Computation flow
-^^^^^^^^^^^^^^^^
+The products, projection logic, assumptions, economic scenarios and input
+workbook are otherwise the same as :mod:`~annuallife.TradLife_A`. Only
+the Spaces that change are described below and on their own pages; for
+everything else, refer to :mod:`~annuallife.TradLife_A`.
 
-Model point data, product specifications, assumptions and economic
-scenarios are all held in an external Excel workbook, *input.xlsx*.
+How the nested projection is implemented
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The spaces are wired together as shown below, and the computation
-proceeds as follows.
+To represent a projection that starts a fresh projection at each
+projection step, a child Space of
+:mod:`~annuallife.TradLife_A_EX1.Projection`,
+:mod:`~annuallife.TradLife_A_EX1.Projection.InnerProj`, is defined.
+``Projection[idx].InnerProj[t0]`` is the inner projection of model point
+``idx`` started at time ``t0``.
 
-.. mermaid::
+:mod:`~annuallife.TradLife_A_EX1.Projection.InnerProj` is parameterized
+with ``t0``, the start time of the inner projection (together with
+``risk`` and ``shock``, which select the life stress). The whole
+projection logic is inherited from :mod:`TradLife_A.BaseProj <annuallife.TradLife_A.BaseProj>`
+and :mod:`TradLife_A.PV <annuallife.TradLife_A.PV>`; only the Cells specific to the
+inner projection are overridden.
 
-    graph LR
-        Projection --> PolicyAttrs
-        Projection --> Assumptions
-        Projection --> CommTable
-        Projection --> Economic
-        PolicyAttrs --> InputData
-        Assumptions --> InputData
-        CommTable --> InputData
-        Economic --> InputData
+The inner projection starts from the state of the outer projection at
+``t0``. The overridden
+:func:`~annuallife.TradLife_A_EX1.Projection.InnerProj.pols_if` returns
+the *outer* projection's in-force at ``t == t0`` and projects forward for
+``t > t0``::
 
-* The data is read into the model from the input file in
-  :mod:`~annuallife.TradLife_A.InputData`, and held there as
-  :mod:`pandas` DataFrames and dicts.
-* :mod:`~annuallife.TradLife_A.InputData` is referenced by
-  :mod:`~annuallife.TradLife_A.PolicyAttrs` and
-  :mod:`~annuallife.TradLife_A.Assumptions`, where policy attributes and
-  assumptions are mapped to model points.
-* :mod:`~annuallife.TradLife_A.InputData` is also referenced by
-  :mod:`~annuallife.TradLife_A.Economic`, where discount rates are
-  calculated.
-* :mod:`~annuallife.TradLife_A.CommTable` calculates commutation
-  functions, and defines actuarial notations. They are used by
-  :mod:`~annuallife.TradLife_A.Projection` to calculate the premium rate
-  for each model point. Mortality rates are provided through
-  :mod:`~annuallife.TradLife_A.InputData`.
-  :mod:`~annuallife.TradLife_A.CommTable` takes three parameters,
-  ``Sex``, ``IntRate`` and ``Table`` (sex, interest rate and mortality
-  table id).
-* :mod:`~annuallife.TradLife_A.Projection` carries out the projection by
-  model point. It takes two parameters: ``idx`` (mandatory) to identify
-  a model point, and ``scen_id`` (optional) to select the economic
-  scenario, defaulting to 1. Policy attributes and assumptions are
-  received from cells in
-  :mod:`~annuallife.TradLife_A.PolicyAttrs` and
-  :mod:`~annuallife.TradLife_A.Assumptions`, which return their values by
-  model point in 1-D :mod:`numpy` arrays, so the ``idx`` parameter
-  indicates the array index, starting from 0.
-* The projection logic is not defined directly in
-  :mod:`~annuallife.TradLife_A.Projection`. Instead, the space inherits
-  all of its logic from two base spaces,
-  :mod:`~annuallife.TradLife_A.BaseProj` and
-  :mod:`~annuallife.TradLife_A.PV`.
+    def pols_if(t):
+        if t == t0:
+            return _space._parent._parent.pols_if(t)
+        else:
+            return pols_if_beg1(t - 1) - pols_death(t - 1) - pols_lapse(t - 1)
 
-For example, the present value of net cashflows for the first model
-point is obtained as::
+In a Cells formula ``_space`` is the current ``InnerProj[t0, risk,
+shock]`` ItemSpace; its parent is the ``InnerProj`` Space and that
+Space's parent is the enclosing ``Projection[idx]`` ItemSpace. So
+``_space._parent._parent`` is the outer projection, and
+``_space._parent._parent.pols_if(t)`` reads its in-force at ``t0``. The
+same idiom is used by the other overridden rate Cells —
+:func:`~annuallife.TradLife_A_EX1.Projection.InnerProj.mort_rate`,
+:func:`~annuallife.TradLife_A_EX1.Projection.InnerProj.lapse_rate` and
+:func:`~annuallife.TradLife_A_EX1.Projection.InnerProj.commissions_ren_pp`
+— which read the unstressed rate from the outer projection and apply the
+life shock to it.
 
-    >>> m.Projection[0].pv_net_cf(0)
+The outer :mod:`~annuallife.TradLife_A_EX1.Projection` reads results back
+from the inner projection by indexing into the child Space. For example,
+:func:`~annuallife.TradLife_A_EX1.Projection.risk_life_sub` evaluates the
+present value of net cashflows of the unstressed and stressed inner
+projections started at ``t`` and takes their difference::
+
+    def risk_life_sub(t, risk):
+        base_pv = InnerProj[t].pv_net_cf(t)
+        ...
+        return max(base_pv - InnerProj[t, risk].pv_net_cf(t), 0)
+
+``InnerProj[t]`` is the unstressed inner projection started at ``t`` and
+``InnerProj[t, risk]`` the one under the ``risk`` stress, with
+:func:`TradLife_A.PV.pv_net_cf <annuallife.TradLife_A.PV.pv_net_cf>` evaluated at ``t`` on each.
+
+Changes from TradLife_A
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. rubric:: New Spaces
+
+* :mod:`~annuallife.TradLife_A_EX1.Projection.InnerProj` — an inner
+  projection, parameterized by the valuation time ``t0`` and a
+  ``(risk, shock)`` pair, that re-runs the cashflow projection under a
+  single prescribed life stress. It inherits from
+  :mod:`TradLife_A.BaseProj <annuallife.TradLife_A.BaseProj>` and
+  :mod:`TradLife_A.PV <annuallife.TradLife_A.PV>` and overrides the decrement,
+  mortality, lapse and expense Cells to apply the shock, taking the
+  unstressed rates from the outer projection.
+* Four enum child Spaces under
+  :mod:`~annuallife.TradLife_A_EX1.Enums` — ``LifeRiskID`` (life
+  sub-risks), ``LapseShockID`` (lapse up / down / mass), ``LapseScopeID``
+  (retail / non-retail) and ``ExtraKeyID`` (extra shock qualifiers).
+
+.. rubric:: Updated Spaces
+
+* :mod:`~annuallife.TradLife_A_EX1.Projection` adds the Solvency II
+  output Cells
+  :func:`~annuallife.TradLife_A_EX1.Projection.risk_life_sub` (capital
+  requirement per life sub-risk),
+  :func:`~annuallife.TradLife_A_EX1.Projection.risk_life` (aggregated
+  life SCR) and
+  :func:`~annuallife.TradLife_A_EX1.Projection.risk_margin` (risk
+  margin), and gains the ``InnerProj`` child Space.
+* :mod:`~annuallife.TradLife_A_EX1.Assumptions` adds
+  :func:`~annuallife.TradLife_A_EX1.Assumptions.life_shock_param` (life
+  shock factors),
+  :func:`~annuallife.TradLife_A_EX1.Assumptions.life_corr` (life-risk
+  correlation coefficient) and
+  :func:`~annuallife.TradLife_A_EX1.Assumptions.coc_rate`
+  (cost-of-capital rate).
+* :mod:`~annuallife.TradLife_A_EX1.InputData` adds
+  :func:`~annuallife.TradLife_A_EX1.InputData.life_shock_data` and
+  :func:`~annuallife.TradLife_A_EX1.InputData.life_corr_data`, which read
+  the ``LifeShocks`` and ``LifeCorr`` named ranges, reads the new
+  ``CoCRate`` value from ``ConstParams``, and generalizes
+  :func:`~annuallife.TradLife_A_EX1.InputData.get_named_range_as_dict` to
+  support named ranges with multi-column (tuple) keys.
+* :mod:`~annuallife.TradLife_A_EX1.PolicyAttrs` adds
+  :func:`~annuallife.TradLife_A_EX1.PolicyAttrs.segment`, the per-policy
+  lapse-risk segment.
+
+The :mod:`TradLife_A.BaseProj <annuallife.TradLife_A.BaseProj>`,
+:mod:`TradLife_A.PV <annuallife.TradLife_A.PV>`,
+:mod:`TradLife_A.Economic <annuallife.TradLife_A.Economic>`,
+:mod:`TradLife_A.CommTable <annuallife.TradLife_A.CommTable>` and
+:mod:`TradLife_A.Utilities <annuallife.TradLife_A.Utilities>` Spaces are unchanged from
+:mod:`~annuallife.TradLife_A`; refer to it for them. In particular the
+life shocks are applied entirely within
+:mod:`~annuallife.TradLife_A_EX1.Projection.InnerProj`, so
+:mod:`TradLife_A.BaseProj <annuallife.TradLife_A.BaseProj>` needs no modification.
+
+.. rubric:: Input workbook
+
+:mod:`~annuallife.TradLife_A_EX1` reads the same *input.xlsx* as
+:mod:`~annuallife.TradLife_A`, with three additional inputs: the
+``LifeShocks`` and ``LifeCorr`` named ranges and a ``CoCRate`` row in
+the ``ConstParams`` range.
 
 Model Structure
 ---------------
 
-In :mod:`~annuallife.TradLife_A`, the following spaces are defined.
+Unlike the rest of this page, which documents only the Spaces that change
+from :mod:`~annuallife.TradLife_A`, this section shows the **complete**
+space structure of the model, so the new and updated Spaces can be seen
+alongside the ones inherited unchanged from
+:mod:`~annuallife.TradLife_A`. The *Status* column marks each Space as
+new, updated or unchanged; the unchanged Spaces link back to
+:mod:`~annuallife.TradLife_A`.
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 80
+   :widths: 24 14 62
 
    * - Space
+     - Status
      - Description
-   * - :mod:`~annuallife.TradLife_A.InputData`
-     - Reads *input.xlsx* and holds its named ranges as :mod:`pandas`
-       DataFrames and dicts.
-   * - :mod:`~annuallife.TradLife_A.Economic`
-     - Parametric space holding scenario-dependent economic assumptions;
-       parameter ``scen_id``.
-   * - :mod:`~annuallife.TradLife_A.BaseProj`
-     - Base space of :mod:`~annuallife.TradLife_A.Projection` containing
-       the cells that produce the per-period cashflow projections.
-   * - :mod:`~annuallife.TradLife_A.PV`
-     - Base space of :mod:`~annuallife.TradLife_A.Projection` containing
-       the cells that compute the present values of those cashflows.
-   * - :mod:`~annuallife.TradLife_A.Projection`
-     - Parametric space whose dynamic ItemSpaces carry out projections
-       for each model point; parameters ``idx`` and ``scen_id``.
-   * - :mod:`~annuallife.TradLife_A.Assumptions`
-     - Holds assumption parameters and rates used by
-       :mod:`~annuallife.TradLife_A.Projection`.
-   * - :mod:`~annuallife.TradLife_A.PolicyAttrs`
-     - Holds policy attributes and policy-level values such as premium
-       and surrender rates used by
-       :mod:`~annuallife.TradLife_A.Projection`.
-   * - :mod:`~annuallife.TradLife_A.Utilities`
-     - Base space of :mod:`~annuallife.TradLife_A.Assumptions` and
-       :mod:`~annuallife.TradLife_A.PolicyAttrs` providing helper cells.
-   * - :mod:`~annuallife.TradLife_A.CommTable`
-     - Parametric space providing commutation functions and actuarial
-       notations; parameters ``Sex``, ``IntRate`` and ``Table``.
-   * - :mod:`~annuallife.TradLife_A.Enums`
-     - Container for the enum types used across the model.
-
-:mod:`~annuallife.TradLife_A.Enums` contains the enum types as child
-spaces, and :mod:`~annuallife.TradLife_A.Assumptions` contains an
-``AsmpID`` child space.
+   * - :mod:`~annuallife.TradLife_A_EX1.InputData`
+     - Updated
+     - Reads *input.xlsx*; adds the ``LifeShocks`` and ``LifeCorr``
+       readers and the ``CoCRate`` constant.
+   * - :mod:`TradLife_A.Economic <annuallife.TradLife_A.Economic>`
+     - Unchanged
+     - Scenario-dependent economic (discount) rates; parameter
+       ``scen_id``.
+   * - :mod:`TradLife_A.BaseProj <annuallife.TradLife_A.BaseProj>`
+     - Unchanged
+     - Per-period cashflow projection cells; base of ``Projection`` and
+       ``InnerProj``.
+   * - :mod:`TradLife_A.PV <annuallife.TradLife_A.PV>`
+     - Unchanged
+     - Present values of the projected cashflows; base of ``Projection``
+       and ``InnerProj``.
+   * - :mod:`~annuallife.TradLife_A_EX1.Projection`
+     - Updated
+     - Per-model-point projection; adds the life SCR and risk-margin
+       Cells and the ``InnerProj`` child Space.
+   * - :mod:`~annuallife.TradLife_A_EX1.Projection.InnerProj`
+     - New
+     - Inner projection re-run under a single life stress, anchored at
+       ``t0``; child Space of ``Projection``.
+   * - :mod:`~annuallife.TradLife_A_EX1.Assumptions`
+     - Updated
+     - Per-policy assumptions; adds the life-shock, correlation and
+       cost-of-capital parameters.
+   * - :mod:`~annuallife.TradLife_A_EX1.PolicyAttrs`
+     - Updated
+     - Per-policy attributes; adds the lapse-risk ``segment``.
+   * - :mod:`TradLife_A.Utilities <annuallife.TradLife_A.Utilities>`
+     - Unchanged
+     - Helper cells (``pandas_to_array``, ``map_to_policies``); base of
+       ``Assumptions`` and ``PolicyAttrs``.
+   * - :mod:`TradLife_A.CommTable <annuallife.TradLife_A.CommTable>`
+     - Unchanged
+     - Commutation functions and actuarial notations; parameters
+       ``Sex``, ``IntRate`` and ``Table``.
+   * - :mod:`~annuallife.TradLife_A_EX1.Enums`
+     - Updated
+     - Enum types; adds the life-risk enums (``LifeRiskID``,
+       ``LapseShockID``, ``LapseScopeID``, ``ExtraKeyID``).
 
 Inheritance
 ^^^^^^^^^^^
 
-:mod:`~annuallife.TradLife_A.Projection` inherits from
-:mod:`~annuallife.TradLife_A.BaseProj` and
-:mod:`~annuallife.TradLife_A.PV`, so projection cells and their
-present-value counterparts share the same parameter scope.
-:mod:`~annuallife.TradLife_A.Assumptions` and
-:mod:`~annuallife.TradLife_A.PolicyAttrs` inherit from
-:mod:`~annuallife.TradLife_A.Utilities`, which contributes the
-``pandas_to_array`` and ``map_to_policies`` helpers.
+As in :mod:`~annuallife.TradLife_A`,
+:mod:`~annuallife.TradLife_A_EX1.Projection` inherits from
+:mod:`TradLife_A.BaseProj <annuallife.TradLife_A.BaseProj>` and
+:mod:`TradLife_A.PV <annuallife.TradLife_A.PV>`, while
+:mod:`~annuallife.TradLife_A_EX1.Assumptions` and
+:mod:`~annuallife.TradLife_A_EX1.PolicyAttrs` inherit from
+:mod:`TradLife_A.Utilities <annuallife.TradLife_A.Utilities>`. The new
+:mod:`~annuallife.TradLife_A_EX1.Projection.InnerProj` also inherits the
+same projection logic from
+:mod:`TradLife_A.BaseProj <annuallife.TradLife_A.BaseProj>` and
+:mod:`TradLife_A.PV <annuallife.TradLife_A.PV>`.
 
 .. mermaid::
 
@@ -146,27 +236,60 @@ present-value counterparts share the same parameter scope.
     classDiagram
         BaseProj <|-- Projection
         PV <|-- Projection
+        BaseProj <|-- InnerProj
+        PV <|-- InnerProj
         Utilities <|-- Assumptions
         Utilities <|-- PolicyAttrs
+
+Composition
+^^^^^^^^^^^
+
+Besides inheritance, the model nests Spaces as child Spaces. The tree
+below is rooted at the :mod:`~annuallife.TradLife_A_EX1` model and
+includes the Spaces inherited unchanged from
+:mod:`~annuallife.TradLife_A`; the new inner projection
+:mod:`~annuallife.TradLife_A_EX1.Projection.InnerProj` is a child Space
+of :mod:`~annuallife.TradLife_A_EX1.Projection`. The enum child Spaces
+under :mod:`~annuallife.TradLife_A_EX1.Enums` (e.g. ``LifeRiskID``) and
+the ``AsmpID`` enum under
+:mod:`~annuallife.TradLife_A_EX1.Assumptions` are omitted from the
+diagram for clarity.
+
+.. mermaid::
+
+    %%{init: {"class": {"hideEmptyMembersBox": true}}}%%
+    classDiagram
+        direction TB
+        TradLife_A_EX1 *-- InputData
+        TradLife_A_EX1 *-- Economic
+        TradLife_A_EX1 *-- BaseProj
+        TradLife_A_EX1 *-- PV
+        TradLife_A_EX1 *-- Projection
+        Projection *-- InnerProj
+        TradLife_A_EX1 *-- Assumptions
+        TradLife_A_EX1 *-- PolicyAttrs
+        TradLife_A_EX1 *-- Utilities
+        TradLife_A_EX1 *-- CommTable
+        TradLife_A_EX1 *-- Enums
 
 Cross-space references
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The cells in :mod:`~annuallife.TradLife_A.Projection` and its base
-spaces resolve a number of References to other spaces:
-
-* ``scen`` -> :mod:`~annuallife.TradLife_A.Economic`
-* ``asmp`` -> :mod:`~annuallife.TradLife_A.Assumptions`
-* ``pol`` -> :mod:`~annuallife.TradLife_A.PolicyAttrs`
-* ``comm_table`` -> :mod:`~annuallife.TradLife_A.CommTable`
-
-:mod:`~annuallife.TradLife_A.Economic`,
-:mod:`~annuallife.TradLife_A.Assumptions`,
-:mod:`~annuallife.TradLife_A.PolicyAttrs` and
-:mod:`~annuallife.TradLife_A.CommTable` each reference the
-:mod:`~annuallife.TradLife_A.InputData` space as ``input_data``.
-:mod:`~annuallife.TradLife_A.CommTable` reads its mortality tables
-through :func:`~annuallife.TradLife_A.InputData.mortality_tables`.
+The cross-space References are the same as in
+:mod:`~annuallife.TradLife_A`:
+:mod:`~annuallife.TradLife_A_EX1.Projection` (and, by inheritance,
+:mod:`~annuallife.TradLife_A_EX1.Projection.InnerProj`) resolve ``scen``,
+``asmp``, ``pol`` and ``comm_table`` to
+:mod:`TradLife_A.Economic <annuallife.TradLife_A.Economic>`,
+:mod:`~annuallife.TradLife_A_EX1.Assumptions`,
+:mod:`~annuallife.TradLife_A_EX1.PolicyAttrs` and
+:mod:`TradLife_A.CommTable <annuallife.TradLife_A.CommTable>`, which in
+turn reference :mod:`~annuallife.TradLife_A_EX1.InputData` as
+``input_data``. In addition,
+:mod:`~annuallife.TradLife_A_EX1.Projection.InnerProj` reads the outer
+:mod:`~annuallife.TradLife_A_EX1.Projection` through
+``_space._parent._parent``, and the outer projection reads results back
+from the inner projections.
 
 .. mermaid::
 
@@ -175,402 +298,38 @@ through :func:`~annuallife.TradLife_A.InputData.mortality_tables`.
         Projection -- asmp --> Assumptions
         Projection -- pol --> PolicyAttrs
         Projection -- comm_table --> CommTable
+        Projection -- risk_life --> InnerProj
+        InnerProj -. reads outer .-> Projection
         Economic -- input_data --> InputData
         Assumptions -- input_data --> InputData
         PolicyAttrs -- input_data --> InputData
         CommTable -- input_data --> InputData
 
-Input File
-----------
-
-:mod:`~annuallife.TradLife_A` reads its data from *input.xlsx*, which is
-located next to the *TradLife_A* model directory inside the library
-folder. The default file name is set by the
-:attr:`~annuallife.TradLife_A.InputData.input_file_name` reference.
-
-The workbook defines the named ranges described below. Each one is read
-through a Cells in :mod:`~annuallife.TradLife_A.InputData`.
-
-.. seealso::
-
-   :mod:`~annuallife.TradLife_A.InputData` for the Cells that load these
-   named ranges and the helpers that turn them into :mod:`pandas`
-   objects.
-
-Model point data
-^^^^^^^^^^^^^^^^
-
-Named range: ``PolicyData``
-
-Per-policy attributes for the model points the projection runs over.
-One row per policy, loaded by
-:func:`~annuallife.TradLife_A.InputData.policy_data` and indexed by
-the ``Policy`` column.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 75
-
-   * - Column
-     - Description
-   * - ``Policy``
-     - Policy ID. Becomes the DataFrame index.
-   * - ``Product``
-     - Product code (``TERM``, ``WL`` or ``ENDW``); a value of the
-       :mod:`~annuallife.TradLife_A.Enums.ProductID` enum.
-   * - ``PolType``
-     - Policy-type sub-category within the product.
-   * - ``Gen``
-     - Product generation / cohort identifier.
-   * - ``Channel``
-     - Distribution channel.
-   * - ``Duration``
-     - Elapsed policy duration in years at the projection start.
-   * - ``Sex``
-     - Insured sex (``M`` or ``F``); a value of the
-       :mod:`~annuallife.TradLife_A.Enums.SexID` enum.
-   * - ``IssueAge``
-     - Age at policy issue.
-   * - ``PaymentMode``
-     - Premium payment mode (number of payments per year).
-   * - ``PremFreq``
-     - Premium-paying period in years.
-   * - ``PolicyTerm``
-     - Term of the policy in years.
-   * - ``MaxPolicyTerm``
-     - Maximum policy term used to cap term-dependent items.
-   * - ``PolicyCount``
-     - Number of policies represented by the model point.
-   * - ``SumAssured``
-     - Sum assured per policy.
-
-Product specifications
-^^^^^^^^^^^^^^^^^^^^^^
-
-Named range: ``ProductSpecTable``
-
-Per-product specification table holding loading parameters, surrender
-charges and the mortality, interest and lapse references used on the
-premium and valuation bases. Read column-by-column by
-:func:`~annuallife.TradLife_A.InputData.product_spec`, which returns
-each column as a Series keyed by ``Product`` / ``PolType`` / ``Gen``.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 75
-
-   * - Column
-     - Description
-   * - ``Product``, ``PolType``, ``Gen``
-     - Lookup keys. ``Product`` matches ``Product`` in ``PolicyData``;
-       ``PolType`` and ``Gen`` are optional refinements and may be left
-       blank for product-wide entries.
-   * - ``LoadAcqSAParam<N>``
-     - Linear parameters of the sum-assured-based acquisition loading,
-       with ``N`` = 1, 2 (see
-       :func:`~annuallife.TradLife_A.PolicyAttrs.load_acq_sa`).
-   * - ``LoadMaintSA``, ``LoadMaintSA2``
-     - Sum-assured-based maintenance loadings during and after the
-       premium-paying period.
-   * - ``LoadMaintPremParam<N>``
-     - Linear parameters of the premium-based maintenance loading,
-       with ``N`` = 1, 2 (see
-       :func:`~annuallife.TradLife_A.PolicyAttrs.load_maint_prem`).
-   * - ``SurrChargeParam<N>``
-     - Parameters of the initial surrender charge, with ``N`` = 1, 2
-       (see :func:`~annuallife.TradLife_A.PolicyAttrs.init_surr_charge`).
-   * - ``MortTable<Basis>``
-     - Mortality table ID (column of ``MortalityTables``) for
-       ``<Basis>``, where ``Basis`` is ``Prem`` (premium basis) or
-       ``Val`` (valuation basis).
-   * - ``IntRate<Basis>``
-     - Interest rate for ``<Basis>``; ``Basis`` as above.
-   * - ``LapseRate<Basis>``
-     - Annual lapse rate for ``<Basis>``; ``Basis`` as above.
-   * - ``Hsx``, ``Tsx``, ``Hax``, ``Tax``
-     - Optional commutation-function parameters for products that need
-       them (left blank for products that do not).
-
-Assumption parameters
-^^^^^^^^^^^^^^^^^^^^^
-
-Named range: ``AssumptionTable``
-
-Table of actuarial assumption parameters — mortality and lapse
-references, commission rates, expense factors, and tax/inflation
-rates — keyed by ``Product`` / ``PolType`` / ``Gen``. Read
-column-by-column by
-:func:`~annuallife.TradLife_A.InputData.assumption`, which returns each
-column as a Series. Rows are sparse: a product-level row sets the
-defaults, and more specific (``PolType`` / ``Gen``) rows override
-individual columns.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 75
-
-   * - Column
-     - Description
-   * - ``Product``, ``PolType``, ``Gen``
-     - Lookup keys for the assumption set.
-   * - ``BaseMort``
-     - Base mortality table ID (column of ``MortalityTables``).
-   * - ``MortFactor``
-     - Name of the ``AsmpByDuration`` column used as a duration-based
-       mortality factor; resolved via
-       :mod:`~annuallife.TradLife_A.Assumptions.AsmpID`.
-   * - ``Surrender``
-     - Name of the ``AsmpByDuration`` column used as the duration-based
-       lapse rate.
-   * - ``Renewal``
-     - Renewal-premium retention assumption.
-   * - ``InvstRet``
-     - Assumed investment return.
-   * - ``CommInitPrem``, ``CommRenPrem``
-     - First-year and renewal-year commission rates as a fraction of
-       premium.
-   * - ``CommRenTerm``
-     - Number of renewal years over which ``CommRenPrem`` applies.
-   * - ``ExpsAcq<Unit>``
-     - Acquisition expense factor per ``<Unit>``, where ``Unit`` is
-       ``SA`` (per sum assured), ``AnnPrem`` (per annualised premium),
-       or ``Pol`` (per policy).
-   * - ``ExpsMaint<Unit>``
-     - Maintenance expense factor per ``<Unit>``, where ``Unit`` is
-       ``SA`` (per sum assured), ``Prem`` (per premium), or ``Pol``
-       (per policy).
-   * - ``InflRate``
-     - Expense inflation rate applied to maintenance expenses.
-   * - ``CnsmpTax``
-     - Consumption-tax rate applied to expenses.
-
-Assumptions by duration
-^^^^^^^^^^^^^^^^^^^^^^^
-
-Named range: ``AsmpByDuration``
-
-Duration-indexed tables of mortality factors, morbidity rates, and
-lapse rates. Read by
-:func:`~annuallife.TradLife_A.InputData.assumption_tables`, which
-returns a ``DataFrame`` indexed by ``Year``. Columns of this range are
-referenced by name from ``AssumptionTable`` (e.g. ``MortFactor`` and
-``Surrender``).
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 75
-
-   * - Column
-     - Description
-   * - ``Year``
-     - Policy duration in years; becomes the DataFrame index.
-   * - ``MortAsmp<N>``
-     - Duration-based mortality-factor tables (``N`` = 1, 2) selectable
-       from ``MortFactor`` in ``AssumptionTable``.
-   * - ``Morb<N>``
-     - Duration-based morbidity-rate tables (``N`` = 1..5; defined for
-       future use, not consumed by the current projection Cells).
-   * - ``LapseRate<N>``
-     - Duration-based lapse-rate tables (``N`` = 1) selectable from
-       ``Surrender`` in ``AssumptionTable``.
-
-Mortality tables
-^^^^^^^^^^^^^^^^
-
-Named range: ``MortalityTables``
-
-Mortality rates by attained age and (mortality table ID, sex), with a
-two-row header (``MortTable`` over ``Sex``). Read by
-:func:`~annuallife.TradLife_A.InputData.mortality_tables`, which
-returns a ``DataFrame`` indexed by age with a column ``MultiIndex`` of
-``(MortTable, Sex)``.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 75
-
-   * - Column
-     - Description
-   * - ``Age`` (row index)
-     - Attained age in years.
-   * - ``MortTable`` (top header)
-     - Mortality table ID (integer); referenced by ``BaseMort`` in
-       ``AssumptionTable`` and by ``MortTablePrem`` / ``MortTableVal``
-       in ``ProductSpecTable``.
-   * - ``Sex`` (sub-header)
-     - Sex code (``M`` or ``F``) within each table.
-   * - Cell value
-     - Annual mortality rate for the (table, sex, age).
-
-Economic scenarios
-^^^^^^^^^^^^^^^^^^
-
-Named range: ``Scenarios``
-
-Read by :func:`~annuallife.TradLife_A.InputData.scenarios`, which
-returns a ``DataFrame`` indexed by ``(ScenID, Year)``.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 75
-
-   * - Column
-     - Description
-   * - ``ScenID``
-     - Scenario ID. Selected through the ``scen_id`` parameter of
-       :mod:`~annuallife.TradLife_A.Economic`.
-   * - ``Year``
-     - Time index (year) within the scenario.
-   * - ``IntRate``
-     - Annual interest rate at time ``Year`` under scenario ``ScenID``.
-
-Large-policy premium discount
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Named range: ``LargePolDiscount``
-
-Two-column range mapping sum-assured bands to a premium discount. Read
-as a :obj:`dict` and turned into a per-policy ``Series`` by
-:func:`~annuallife.TradLife_A.InputData.discount_rate`, which uses the
-keys as left-closed band boundaries.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 75
-
-   * - Column
-     - Description
-   * - First column
-     - Upper bound of the sum-assured band. The last row may be left
-       blank, in which case the final band has no upper bound.
-   * - Second column
-     - Premium discount applied to policies whose ``SumAssured`` falls
-       in that band.
-
-Premium-waiver cost
-^^^^^^^^^^^^^^^^^^^
-
-Named range: ``PremiumWaiverCost``
-
-Two-column range mapping policy-term bands to a premium-waiver loading.
-Read as a :obj:`dict` by
-:func:`~annuallife.TradLife_A.InputData.prem_waiver_cost`.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 75
-
-   * - Column
-     - Description
-   * - First column
-     - Upper bound of the policy-term band. The last row may be left
-       blank, in which case the final band has no upper bound.
-   * - Second column
-     - Premium-waiver cost loading for that band.
-
-Constant parameters
-^^^^^^^^^^^^^^^^^^^
-
-Named range: ``ConstParams``
-
-Two-column range of scalar parameters used across the model. Read as a
-:obj:`dict` by :func:`~annuallife.TradLife_A.InputData.const_params`.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 75
-
-   * - Column
-     - Description
-   * - First column
-     - Parameter name (e.g. ``InflRate``, ``CnsmpTax``).
-   * - Second column
-     - Parameter value.
-
-.. _tradlife_a-basic-usage:
-
 Basic Usage
 -----------
 
-Reading the model
-^^^^^^^^^^^^^^^^^
-
-Create your copy of the *annuallife* library by following the steps on
-the :doc:`/quickstart/index` page. The model is saved as the folder
-``TradLife_A`` in the copied folder, with *input.xlsx* placed next to
-it.
-
-To read the model from Spyder with the modelx plug-in, right-click on
-the empty space in *MxExplorer*, select *Read Model*, and choose the
-*TradLife_A* folder.
-
-To read the model on an IPython console, use ``read_model`` after
-changing the current directory to the library folder so the workbook is
-discoverable:
-
-.. code-block:: python
+Read and run the model exactly as :mod:`~annuallife.TradLife_A` (see its
+:ref:`Basic Usage <tradlife_a-basic-usage>` section), using the
+``TradLife_A_EX1`` folder::
 
     >>> import modelx as mx
 
-    >>> m = mx.read_model("TradLife_A")
+    >>> m = mx.read_model("TradLife_A_EX1")
 
-Running results
-^^^^^^^^^^^^^^^
+The Solvency II results are obtained from the
+:mod:`~annuallife.TradLife_A_EX1.Projection` Space, for example::
 
-Projection results are obtained by calling the cells of an ItemSpace of
-:mod:`~annuallife.TradLife_A.Projection` with a specific ``idx`` (and
-optionally ``scen_id``):
+    >>> m.Projection[0].risk_life(0)        # aggregated life SCR at t=0
 
-.. code-block:: python
+    >>> m.Projection[0].risk_margin(0)      # risk margin at t=0
 
-    >>> m.Projection[0].pv_net_cf(0)            # PV of net cashflow at t=0
-    >>> m.Projection[0].net_cf(5)               # Net cashflow at t=5
-    >>> m.Projection[0].premiums(0)             # Premium income at t=0
-    >>> m.Projection[0].claims(0)               # Death claims at t=0
-
-The plot scripts ``plot_tradlife_a.py`` and ``plot_pvcashflows_tradlife_a.py``
-in the library folder demonstrate how to produce stacked-bar charts of
-the cashflow components and their present values.
-
-Exporting the model
-^^^^^^^^^^^^^^^^^^^
-
-The model can be exported to a pure-Python (nomx) module that does not
-depend on modelx. Use the ``export`` method on the model object::
-
-    >>> m.export("TradLife_A_nomx")
-
-This command exports the model as a Python package named
-``TradLife_A_nomx`` in the current directory. You can test the exported
-(nomx) model by importing it and accessing its cells::
-
-    >>> from TradLife_A_nomx import mx_model
-
-    >>> mx_model.Projection[0].pv_net_cf(0)
-
-(Here, ``mx_model`` is the nomx model object.)
+    >>> m.Projection[0].risk_life_sub(0, m.Enums.LifeRiskID.MORT)
 
 Global References
 -----------------
 
-Global references are names that can be referenced from formulas in any
-space in the model. The third-party modules
-`pandas <https://pandas.pydata.org/>`__ and
-`numpy <https://numpy.org/>`__ are defined here, as are the enum types
-defined as child spaces under :mod:`~annuallife.TradLife_A.Enums`.
-
-Attributes:
-    pd: The `pandas <https://pandas.pydata.org/>`__ module.
-    np: The `numpy <https://numpy.org/>`__ module.
-    ProductID: The product-type enum,
-        :mod:`~annuallife.TradLife_A.Enums.ProductID` (``TERM`` term
-        insurance, ``WL`` whole life, ``ENDW`` endowment).
-    SexID: The sex enum,
-        :mod:`~annuallife.TradLife_A.Enums.SexID` (``M`` male,
-        ``F`` female).
-    RateBasisID: The rate-basis enum,
-        :mod:`~annuallife.TradLife_A.Enums.RateBasisID` (``PREM`` premium
-        basis, ``VAL`` valuation basis).
+The model-level References (``pd``, ``np``, ``ProductID``, ``SexID`` and
+``RateBasisID``) are the same as in :mod:`~annuallife.TradLife_A`.
 
 """
 


### PR DESCRIPTION
## What

Documents the **TradLife_A_EX1** nested-projection example, treating it as a *delta* of **TradLife_A** rather than re-documenting components inherited unchanged.

### Model page & docstrings
- Rewrote the model docstring to lead with the **demonstration intent** — how to build a nested projection in modelx — with an Overview subsection *"How the nested projection is implemented"* followed by *"Changes from TradLife_A"*.
- Added a **Model Structure** section (like TradLife_A) with **Inheritance**, **Composition** and **Cross-space references** diagrams. The diagrams show both the updated and the unchanged Spaces, and the prose says so. Enum child Spaces are omitted from the composition diagram for clarity (noted in the text).
- Documented **only the Spaces that change** from TradLife_A — `Assumptions`, `Enums`, `InputData`, `PolicyAttrs`, `Projection`, `InnerProj`. Unchanged Spaces (e.g. `BaseProj`, which is byte-identical to TradLife_A after #149) keep their original docstrings and the page refers to TradLife_A for them.
- Added **Cells Summary** sections (New / Updated cells) to the documented Spaces and wrote docstrings for the new cells that were missing them.
- Cross-references to **TradLife_A** objects display the model name explicitly (e.g. `TradLife_A.Assumptions`); links within TradLife_A_EX1 stay short.
- Added the model page `TradLife_A_EX1.rst` and per-Space rst pages, ordered to match TradLife_A's Space order.

### annuallife library page (`index.rst`)
- Added a *"Nested projection example"* subsection introducing TradLife_A_EX1, and listed it plus the EX1 plot scripts in **Library Contents**.
- Described the `plot_*.py` scripts the same way the **savings** library does — `Python script for :doc:\`/generated_examples/...\`` — instead of the more technical "sphinx-gallery plot script" wording.

## Why

TradLife_A_EX1 reuses the structure, assumptions and input data of TradLife_A; its purpose is to demonstrate the nested-projection pattern (the Solvency II life-risk SCR / risk margin is just the illustrative example). Documenting it as a delta keeps the focus on what's new and avoids duplicating the TradLife_A reference.

## Notes for reviewers
- **Docstring-only / docs-only change** — no model code changed. The `def`/`return` lines in the `__init__.py` diffs are code *examples* inside the rewritten module docstrings.
- Verified with a full Sphinx build (gallery executed, notebooks not): exit 0, **0 annuallife/TradLife_A_EX1 warnings**, no malformed-table or broken cross-reference warnings; all five gallery target pages generate and the Library Contents links resolve.