### PR TITLE
REF: Rename disc_rate_mth to disc_rate in TradLife_A models

### DIFF
--- a/doc/source/libraries/annuallife/BaseProj.rst
+++ b/doc/source/libraries/annuallife/BaseProj.rst
@@ -35,7 +35,7 @@ Cells Descriptions
 
 .. autofunction:: inflation_factor
 
-.. autofunction:: disc_rate_mth
+.. autofunction:: disc_rate
 
 .. autofunction:: pols_if_init
 

--- a/doc/source/libraries/annuallife/Economic.rst
+++ b/doc/source/libraries/annuallife/Economic.rst
@@ -7,6 +7,6 @@ The **Economic** Space
 Cells Descriptions
 ------------------
 
-.. autofunction:: disc_rate_mth
+.. autofunction:: disc_rate
 
 .. autofunction:: invst_ret_rate

--- a/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/BaseProj/__init__.py
@@ -63,7 +63,7 @@ rates, surrender charge, inflation and discounting.
    ~cash_value_rate
    ~surr_charge
    ~inflation_factor
-   ~disc_rate_mth
+   ~disc_rate
 
 
 Policy Decrement
@@ -418,7 +418,7 @@ def int_accum_cf(t):
     """Interest on accumulated cashflows"""
     return (accum_cf(t)
             + premiums(t)
-            - expenses(t)) * disc_rate_mth(t)
+            - expenses(t)) * disc_rate(t)
 
 
 def invst_income(t):
@@ -938,13 +938,13 @@ def inflation_factor(t):
         return inflation_factor(t-1) * (1 + asmp.inflation_rate())
 
 
-def disc_rate_mth(t):
+def disc_rate(t):
     """Discount rate at time ``t``.
 
     Refers to
-    :func:`Economic[scen_id].disc_rate_mth<annuallife.TradLife_A.Economic.disc_rate_mth>`.
+    :func:`Economic[scen_id].disc_rate<annuallife.TradLife_A.Economic.disc_rate>`.
     """
-    return scen.disc_rate_mth(t)
+    return scen.disc_rate(t)
 
 
 # ---------------------------------------------------------------------------

--- a/lifelib/libraries/annuallife/TradLife_A/Economic/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/Economic/__init__.py
@@ -36,7 +36,7 @@ Example:
 
     An example of ``Economic`` in :mod:`~annuallife.TradLife_A`::
 
-        >>> m.Economic[1].disc_rate_mth(0)
+        >>> m.Economic[1].disc_rate(0)
         0.015
 
 
@@ -48,7 +48,7 @@ scenario at time ``t``.
 
 .. autosummary::
 
-   ~disc_rate_mth
+   ~disc_rate
    ~invst_ret_rate
 
 """
@@ -66,7 +66,7 @@ _spaces = []
 # ---------------------------------------------------------------------------
 # Cells
 
-def disc_rate_mth(t):
+def disc_rate(t):
     """Discount rate at time ``t``.
 
     Read from the ``Scenarios`` range in *input.xlsx* (column
@@ -80,9 +80,9 @@ def disc_rate_mth(t):
 def invst_ret_rate(t):
     """Rate of investment return at time ``t``.
 
-    Set equal to :func:`disc_rate_mth`.
+    Set equal to :func:`disc_rate`.
     """
-    return disc_rate_mth(t)
+    return disc_rate(t)
 
 
 # ---------------------------------------------------------------------------

--- a/lifelib/libraries/annuallife/TradLife_A/PV/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/PV/__init__.py
@@ -13,8 +13,8 @@ Each present-value cell is defined recursively in ``t``: the recursion
 terminates at ``t > proj_len()`` by returning ``0``, where
 :func:`~annuallife.TradLife_A.BaseProj.proj_len` is the projection
 length for the selected policy. Discounting uses the
-:func:`~annuallife.TradLife_A.BaseProj.disc_rate_mth` cell that resolves
-to :func:`~annuallife.TradLife_A.Economic.disc_rate_mth` for the
+:func:`~annuallife.TradLife_A.BaseProj.disc_rate` cell that resolves
+to :func:`~annuallife.TradLife_A.Economic.disc_rate` for the
 selected scenario.
 
 
@@ -105,14 +105,14 @@ def interest_net_cf(t):
         * :func:`pv_net_cf`
         * :func:`~annuallife.TradLife_A.BaseProj.premiums`
         * :func:`~annuallife.TradLife_A.BaseProj.expenses`
-        * :func:`~annuallife.TradLife_A.BaseProj.disc_rate_mth`
+        * :func:`~annuallife.TradLife_A.BaseProj.disc_rate`
     """
     if t > proj_len():
         return 0
     else:
         return (pv_net_cf(t)
                 - premiums(t)
-                + expenses(t)) * disc_rate_mth(t)
+                + expenses(t)) * disc_rate(t)
 
 
 def pv_claims_death(t):
@@ -126,7 +126,7 @@ def pv_claims_death(t):
     if t > proj_len():
         return 0
     else:
-        return (claims_death(t) + pv_claims_death(t+1)) / (1 + disc_rate_mth(t))
+        return (claims_death(t) + pv_claims_death(t+1)) / (1 + disc_rate(t))
 
 
 def pv_claims_mat(t):
@@ -140,7 +140,7 @@ def pv_claims_mat(t):
     if t > proj_len():
         return 0
     else:
-        return (claims_mat(t) + pv_claims_mat(t+1)) / (1 + disc_rate_mth(t))
+        return (claims_mat(t) + pv_claims_mat(t+1)) / (1 + disc_rate(t))
 
 
 def pv_claims_surr(t):
@@ -154,7 +154,7 @@ def pv_claims_surr(t):
     if t > proj_len():
         return 0
     else:
-        return (claims_surr(t) + pv_claims_surr(t+1)) / (1 + disc_rate_mth(t))
+        return (claims_surr(t) + pv_claims_surr(t+1)) / (1 + disc_rate(t))
 
 
 def pv_claims(t):
@@ -170,7 +170,7 @@ def pv_claims(t):
     if t > proj_len():
         return 0
     else:
-        return (claims(t) + pv_claims(t+1)) / (1 + disc_rate_mth(t))
+        return (claims(t) + pv_claims(t+1)) / (1 + disc_rate(t))
 
 
 def pv_check(t):
@@ -198,7 +198,7 @@ def pv_exps_acq(t):
     if t > proj_len():
         return 0
     else:
-        return exps_acq(t) + pv_exps_acq(t+1) / (1 + disc_rate_mth(t))
+        return exps_acq(t) + pv_exps_acq(t+1) / (1 + disc_rate(t))
 
 
 def pv_commissions(t):
@@ -212,7 +212,7 @@ def pv_commissions(t):
     if t > proj_len():
         return 0
     else:
-        return commissions(t) + pv_commissions(t+1) / (1 + disc_rate_mth(t))
+        return commissions(t) + pv_commissions(t+1) / (1 + disc_rate(t))
 
 
 def pv_exps_maint(t):
@@ -226,7 +226,7 @@ def pv_exps_maint(t):
     if t > proj_len():
         return 0
     else:
-        return exps_maint(t) + pv_exps_maint(t+1) / (1 + disc_rate_mth(t))
+        return exps_maint(t) + pv_exps_maint(t+1) / (1 + disc_rate(t))
 
 
 def pv_expenses(t):
@@ -242,7 +242,7 @@ def pv_expenses(t):
     if t > proj_len():
         return 0
     else:
-        return expenses(t) + pv_expenses(t+1) / (1 + disc_rate_mth(t))
+        return expenses(t) + pv_expenses(t+1) / (1 + disc_rate(t))
 
 
 def pv_net_cf(t):
@@ -282,8 +282,8 @@ def pv_net_cf_for_check(t):
     else:
         return (premiums(t)
                 - expenses(t)
-                - claims(t) / (1 + disc_rate_mth(t))
-                + pv_net_cf(t+1) / (1 + disc_rate_mth(t)))
+                - claims(t) / (1 + disc_rate(t))
+                + pv_net_cf(t+1) / (1 + disc_rate(t)))
 
 
 def pv_premiums(t):
@@ -297,7 +297,7 @@ def pv_premiums(t):
     if t > proj_len():
         return 0
     else:
-        return premiums(t) + pv_premiums(t+1) / (1 + disc_rate_mth(t))
+        return premiums(t) + pv_premiums(t+1) / (1 + disc_rate(t))
 
 
 def pv_sum_insur_if(t):
@@ -311,6 +311,6 @@ def pv_sum_insur_if(t):
     if t > proj_len():
         return 0
     else:
-        return insur_if_beg1(t) + pv_sum_insur_if(t+1) / (1 + disc_rate_mth(t))
+        return insur_if_beg1(t) + pv_sum_insur_if(t+1) / (1 + disc_rate(t))
 
 

--- a/lifelib/libraries/annuallife/TradLife_A_EX1/BaseProj/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/BaseProj/__init__.py
@@ -63,7 +63,7 @@ rates, surrender charge, inflation and discounting.
    ~cash_value_rate
    ~surr_charge
    ~inflation_factor
-   ~disc_rate_mth
+   ~disc_rate
 
 
 Policy Decrement
@@ -418,7 +418,7 @@ def int_accum_cf(t):
     """Interest on accumulated cashflows"""
     return (accum_cf(t)
             + premiums(t)
-            - expenses(t)) * disc_rate_mth(t)
+            - expenses(t)) * disc_rate(t)
 
 
 def invst_income(t):
@@ -938,13 +938,13 @@ def inflation_factor(t):
         return inflation_factor(t-1) * (1 + asmp.inflation_rate())
 
 
-def disc_rate_mth(t):
+def disc_rate(t):
     """Discount rate at time ``t``.
 
     Refers to
-    :func:`Economic[scen_id].disc_rate_mth<annuallife.TradLife_A.Economic.disc_rate_mth>`.
+    :func:`Economic[scen_id].disc_rate<annuallife.TradLife_A.Economic.disc_rate>`.
     """
-    return scen.disc_rate_mth(t)
+    return scen.disc_rate(t)
 
 
 # ---------------------------------------------------------------------------

--- a/lifelib/libraries/annuallife/TradLife_A_EX1/Economic/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/Economic/__init__.py
@@ -36,7 +36,7 @@ Example:
 
     An example of ``Economic`` in :mod:`~annuallife.TradLife_A`::
 
-        >>> m.Economic[1].disc_rate_mth(0)
+        >>> m.Economic[1].disc_rate(0)
         0.015
 
 
@@ -48,7 +48,7 @@ scenario at time ``t``.
 
 .. autosummary::
 
-   ~disc_rate_mth
+   ~disc_rate
    ~invst_ret_rate
 
 """
@@ -66,7 +66,7 @@ _spaces = []
 # ---------------------------------------------------------------------------
 # Cells
 
-def disc_rate_mth(t):
+def disc_rate(t):
     """Discount rate at time ``t``.
 
     Read from the ``Scenarios`` range in *input.xlsx* (column
@@ -80,9 +80,9 @@ def disc_rate_mth(t):
 def invst_ret_rate(t):
     """Rate of investment return at time ``t``.
 
-    Set equal to :func:`disc_rate_mth`.
+    Set equal to :func:`disc_rate`.
     """
-    return disc_rate_mth(t)
+    return disc_rate(t)
 
 
 # ---------------------------------------------------------------------------

--- a/lifelib/libraries/annuallife/TradLife_A_EX1/PV/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/PV/__init__.py
@@ -13,8 +13,8 @@ Each present-value cell is defined recursively in ``t``: the recursion
 terminates at ``t > proj_len()`` by returning ``0``, where
 :func:`~annuallife.TradLife_A.BaseProj.proj_len` is the projection
 length for the selected policy. Discounting uses the
-:func:`~annuallife.TradLife_A.BaseProj.disc_rate_mth` cell that resolves
-to :func:`~annuallife.TradLife_A.Economic.disc_rate_mth` for the
+:func:`~annuallife.TradLife_A.BaseProj.disc_rate` cell that resolves
+to :func:`~annuallife.TradLife_A.Economic.disc_rate` for the
 selected scenario.
 
 
@@ -105,14 +105,14 @@ def interest_net_cf(t):
         * :func:`pv_net_cf`
         * :func:`~annuallife.TradLife_A.BaseProj.premiums`
         * :func:`~annuallife.TradLife_A.BaseProj.expenses`
-        * :func:`~annuallife.TradLife_A.BaseProj.disc_rate_mth`
+        * :func:`~annuallife.TradLife_A.BaseProj.disc_rate`
     """
     if t > proj_len():
         return 0
     else:
         return (pv_net_cf(t)
                 - premiums(t)
-                + expenses(t)) * disc_rate_mth(t)
+                + expenses(t)) * disc_rate(t)
 
 
 def pv_claims_death(t):
@@ -126,7 +126,7 @@ def pv_claims_death(t):
     if t > proj_len():
         return 0
     else:
-        return (claims_death(t) + pv_claims_death(t+1)) / (1 + disc_rate_mth(t))
+        return (claims_death(t) + pv_claims_death(t+1)) / (1 + disc_rate(t))
 
 
 def pv_claims_mat(t):
@@ -140,7 +140,7 @@ def pv_claims_mat(t):
     if t > proj_len():
         return 0
     else:
-        return (claims_mat(t) + pv_claims_mat(t+1)) / (1 + disc_rate_mth(t))
+        return (claims_mat(t) + pv_claims_mat(t+1)) / (1 + disc_rate(t))
 
 
 def pv_claims_surr(t):
@@ -154,7 +154,7 @@ def pv_claims_surr(t):
     if t > proj_len():
         return 0
     else:
-        return (claims_surr(t) + pv_claims_surr(t+1)) / (1 + disc_rate_mth(t))
+        return (claims_surr(t) + pv_claims_surr(t+1)) / (1 + disc_rate(t))
 
 
 def pv_claims(t):
@@ -170,7 +170,7 @@ def pv_claims(t):
     if t > proj_len():
         return 0
     else:
-        return (claims(t) + pv_claims(t+1)) / (1 + disc_rate_mth(t))
+        return (claims(t) + pv_claims(t+1)) / (1 + disc_rate(t))
 
 
 def pv_check(t):
@@ -198,7 +198,7 @@ def pv_exps_acq(t):
     if t > proj_len():
         return 0
     else:
-        return exps_acq(t) + pv_exps_acq(t+1) / (1 + disc_rate_mth(t))
+        return exps_acq(t) + pv_exps_acq(t+1) / (1 + disc_rate(t))
 
 
 def pv_commissions(t):
@@ -212,7 +212,7 @@ def pv_commissions(t):
     if t > proj_len():
         return 0
     else:
-        return commissions(t) + pv_commissions(t+1) / (1 + disc_rate_mth(t))
+        return commissions(t) + pv_commissions(t+1) / (1 + disc_rate(t))
 
 
 def pv_exps_maint(t):
@@ -226,7 +226,7 @@ def pv_exps_maint(t):
     if t > proj_len():
         return 0
     else:
-        return exps_maint(t) + pv_exps_maint(t+1) / (1 + disc_rate_mth(t))
+        return exps_maint(t) + pv_exps_maint(t+1) / (1 + disc_rate(t))
 
 
 def pv_expenses(t):
@@ -242,7 +242,7 @@ def pv_expenses(t):
     if t > proj_len():
         return 0
     else:
-        return expenses(t) + pv_expenses(t+1) / (1 + disc_rate_mth(t))
+        return expenses(t) + pv_expenses(t+1) / (1 + disc_rate(t))
 
 
 def pv_net_cf(t):
@@ -282,8 +282,8 @@ def pv_net_cf_for_check(t):
     else:
         return (premiums(t)
                 - expenses(t)
-                - claims(t) / (1 + disc_rate_mth(t))
-                + pv_net_cf(t+1) / (1 + disc_rate_mth(t)))
+                - claims(t) / (1 + disc_rate(t))
+                + pv_net_cf(t+1) / (1 + disc_rate(t)))
 
 
 def pv_premiums(t):
@@ -297,7 +297,7 @@ def pv_premiums(t):
     if t > proj_len():
         return 0
     else:
-        return premiums(t) + pv_premiums(t+1) / (1 + disc_rate_mth(t))
+        return premiums(t) + pv_premiums(t+1) / (1 + disc_rate(t))
 
 
 def pv_sum_insur_if(t):
@@ -311,6 +311,6 @@ def pv_sum_insur_if(t):
     if t > proj_len():
         return 0
     else:
-        return insur_if_beg1(t) + pv_sum_insur_if(t+1) / (1 + disc_rate_mth(t))
+        return insur_if_beg1(t) + pv_sum_insur_if(t+1) / (1 + disc_rate(t))
 
 

--- a/lifelib/libraries/annuallife/TradLife_A_EX1/Projection/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/Projection/__init__.py
@@ -165,7 +165,7 @@ def risk_margin(t):
         \mathrm{risk\_margin}(t) = \mathrm{CoC}
         \sum_{s=t}^{\mathrm{proj\_len}}
         \frac{\mathrm{risk\_life}(s)}
-        {\prod_{u=t}^{s}\left(1 + \mathrm{disc\_rate\_mth}(u)\right)}
+        {\prod_{u=t}^{s}\left(1 + \mathrm{disc\_rate}(u)\right)}
 
     The cost of capital for the capital held over year ``[s, s+1]`` is
     taken to be incurred at ``s + 1``, so each ``risk_life(s)`` is
@@ -177,7 +177,7 @@ def risk_margin(t):
         \mathrm{risk\_margin}(t) =
         \frac{\mathrm{CoC}\cdot\mathrm{risk\_life}(t)
         + \mathrm{risk\_margin}(t + 1)}
-        {1 + \mathrm{disc\_rate\_mth}(t)}
+        {1 + \mathrm{disc\_rate}(t)}
 
     which terminates at ``0`` once ``t`` is beyond
     :func:`TradLife_A.BaseProj.proj_len <annuallife.TradLife_A.BaseProj.proj_len>`. At ``t = 0`` it is
@@ -195,7 +195,7 @@ def risk_margin(t):
         return 0
     else:
         return (asmp.coc_rate() * risk_life(t)
-                + risk_margin(t + 1)) / (1 + disc_rate_mth(t))
+                + risk_margin(t + 1)) / (1 + disc_rate(t))
 
 
 # ---------------------------------------------------------------------------

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/BaseProj/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/BaseProj/__init__.py
@@ -58,7 +58,7 @@ rates, surrender charge, inflation and discounting.
    ~cash_value_rate
    ~surr_charge
    ~inflation_factor
-   ~disc_rate_mth
+   ~disc_rate
 
 
 Policy Decrement
@@ -413,7 +413,7 @@ def int_accum_cf(t):
     """Interest on accumulated cashflows"""
     return (accum_cf(t)
             + premiums(t)
-            - expenses(t)) * disc_rate_mth(t)
+            - expenses(t)) * disc_rate(t)
 
 
 def invst_income(t):
@@ -823,13 +823,13 @@ def inflation_factor(t):
         return inflation_factor(t-1) * (1 + asmp.inflation_rate())
 
 
-def disc_rate_mth(t):
+def disc_rate(t):
     """Discount rate at time ``t``.
 
     Refers to
-    :func:`Economic[scen_id].disc_rate_mth<annuallife.TradLife_A.Economic.disc_rate_mth>`.
+    :func:`Economic[scen_id].disc_rate<annuallife.TradLife_A.Economic.disc_rate>`.
     """
-    return scen.disc_rate_mth(t)
+    return scen.disc_rate(t)
 
 
 # ---------------------------------------------------------------------------

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/Economic/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/Economic/__init__.py
@@ -31,7 +31,7 @@ Example:
 
     An example of ``Economic`` in :mod:`~annuallife.TradLife_A`::
 
-        >>> m.Economic[1].disc_rate_mth(0)
+        >>> m.Economic[1].disc_rate(0)
         0.015
 
 
@@ -43,7 +43,7 @@ scenario at time ``t``.
 
 .. autosummary::
 
-   ~disc_rate_mth
+   ~disc_rate
    ~invst_ret_rate
 
 """
@@ -61,7 +61,7 @@ _spaces = []
 # ---------------------------------------------------------------------------
 # Cells
 
-def disc_rate_mth(t):
+def disc_rate(t):
     """Discount rate at time ``t``.
 
     Read from the ``Scenarios`` range in *input.xlsx* (column
@@ -75,9 +75,9 @@ def disc_rate_mth(t):
 def invst_ret_rate(t):
     """Rate of investment return at time ``t``.
 
-    Set equal to :func:`disc_rate_mth`.
+    Set equal to :func:`disc_rate`.
     """
-    return disc_rate_mth(t)
+    return disc_rate(t)
 
 
 # ---------------------------------------------------------------------------

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/PV/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/PV/__init__.py
@@ -8,8 +8,8 @@ Each present-value cell is defined recursively in ``t``: the recursion
 terminates at ``t > proj_len()`` by returning ``0``, where
 :func:`~annuallife.TradLife_A.BaseProj.proj_len` is the projection
 length for the selected policy. Discounting uses the
-:func:`~annuallife.TradLife_A.BaseProj.disc_rate_mth` cell that resolves
-to :func:`~annuallife.TradLife_A.Economic.disc_rate_mth` for the
+:func:`~annuallife.TradLife_A.BaseProj.disc_rate` cell that resolves
+to :func:`~annuallife.TradLife_A.Economic.disc_rate` for the
 selected scenario.
 
 
@@ -99,7 +99,7 @@ def interest_net_cf(t):
     else:
         return (pv_net_cf(t)
                 - premiums(t)
-                + expenses(t)) * disc_rate_mth(t)
+                + expenses(t)) * disc_rate(t)
 
 
 def pv_claims_death(t):
@@ -107,7 +107,7 @@ def pv_claims_death(t):
     if t > proj_len():
         return 0
     else:
-        return (-claims_death(t) + pv_claims_death(t+1)) / (1 + disc_rate_mth(t))
+        return (-claims_death(t) + pv_claims_death(t+1)) / (1 + disc_rate(t))
 
 
 def pv_claims_mat(t):
@@ -115,7 +115,7 @@ def pv_claims_mat(t):
     if t > proj_len():
         return 0
     else:
-        return (-claims_mat(t) + pv_claims_mat(t+1)) / (1 + disc_rate_mth(t))
+        return (-claims_mat(t) + pv_claims_mat(t+1)) / (1 + disc_rate(t))
 
 
 def pv_claims_surr(t):
@@ -123,7 +123,7 @@ def pv_claims_surr(t):
     if t > proj_len():
         return 0
     else:
-        return (-claims_surr(t) + pv_claims_surr(t+1)) / (1 + disc_rate_mth(t))
+        return (-claims_surr(t) + pv_claims_surr(t+1)) / (1 + disc_rate(t))
 
 
 def pv_claims(t):
@@ -131,7 +131,7 @@ def pv_claims(t):
     if t > proj_len():
         return 0
     else:
-        return (-claims(t) + pv_claims(t+1)) / (1 + disc_rate_mth(t))
+        return (-claims(t) + pv_claims(t+1)) / (1 + disc_rate(t))
 
 
 def pv_check(t):
@@ -148,7 +148,7 @@ def pv_exps_acq(t):
     if t > proj_len():
         return 0
     else:
-        return - exps_acq(t) + pv_exps_acq(t+1) / (1 + disc_rate_mth(t))
+        return - exps_acq(t) + pv_exps_acq(t+1) / (1 + disc_rate(t))
 
 
 def pv_commissions(t):
@@ -156,7 +156,7 @@ def pv_commissions(t):
     if t > proj_len():
         return 0
     else:
-        return - commissions(t) + pv_commissions(t+1) / (1 + disc_rate_mth(t))
+        return - commissions(t) + pv_commissions(t+1) / (1 + disc_rate(t))
 
 
 def pv_exps_maint(t):
@@ -164,7 +164,7 @@ def pv_exps_maint(t):
     if t > proj_len():
         return 0
     else:
-        return - exps_maint(t) + pv_exps_maint(t+1) / (1 + disc_rate_mth(t))
+        return - exps_maint(t) + pv_exps_maint(t+1) / (1 + disc_rate(t))
 
 
 def pv_expenses(t):
@@ -172,7 +172,7 @@ def pv_expenses(t):
     if t > proj_len():
         return 0
     else:
-        return - expenses(t) + pv_expenses(t+1) / (1 + disc_rate_mth(t))
+        return - expenses(t) + pv_expenses(t+1) / (1 + disc_rate(t))
 
 
 def pv_net_cf(t):
@@ -194,8 +194,8 @@ def pv_net_cf_for_check(t):
     else:
         return (premiums(t)
                 - expenses(t)
-                - claims(t) / (1 + disc_rate_mth(t))
-                + pv_net_cf(t+1) / (1 + disc_rate_mth(t)))
+                - claims(t) / (1 + disc_rate(t))
+                + pv_net_cf(t+1) / (1 + disc_rate(t)))
 
 
 def pv_premiums(t):
@@ -203,7 +203,7 @@ def pv_premiums(t):
     if t > proj_len():
         return 0
     else:
-        return premiums(t) + pv_premiums(t+1) / (1 + disc_rate_mth(t))
+        return premiums(t) + pv_premiums(t+1) / (1 + disc_rate(t))
 
 
 def pv_sum_insur_if(t):
@@ -211,6 +211,6 @@ def pv_sum_insur_if(t):
     if t > proj_len():
         return 0
     else:
-        return insur_if_beg1(t) + pv_sum_insur_if(t+1) / (1 + disc_rate_mth(t))
+        return insur_if_beg1(t) + pv_sum_insur_if(t+1) / (1 + disc_rate(t))
 
 

--- a/lifelib/libraries/annuallife/tradlife_a-space-overview.ipynb
+++ b/lifelib/libraries/annuallife/tradlife_a-space-overview.ipynb
@@ -25,7 +25,14 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "eabf0f1c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T01:22:21.108390Z",
+     "iopub.status.busy": "2026-06-28T01:22:21.108222Z",
+     "iopub.status.idle": "2026-06-28T01:22:21.112457Z",
+     "shell.execute_reply": "2026-06-28T01:22:21.112109Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import sys, os\n",
@@ -53,7 +60,14 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "fca71bf1",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T01:22:21.113868Z",
+     "iopub.status.busy": "2026-06-28T01:22:21.113708Z",
+     "iopub.status.idle": "2026-06-28T01:22:22.015435Z",
+     "shell.execute_reply": "2026-06-28T01:22:22.015035Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import modelx as mx\n",
@@ -72,7 +86,14 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "ce48df4c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T01:22:22.017110Z",
+     "iopub.status.busy": "2026-06-28T01:22:22.016868Z",
+     "iopub.status.idle": "2026-06-28T01:22:22.021097Z",
+     "shell.execute_reply": "2026-06-28T01:22:22.020798Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -104,7 +125,14 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "ee49e17b",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T01:22:22.022485Z",
+     "iopub.status.busy": "2026-06-28T01:22:22.022323Z",
+     "iopub.status.idle": "2026-06-28T01:22:22.025285Z",
+     "shell.execute_reply": "2026-06-28T01:22:22.024742Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -133,7 +161,14 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "ef6251bc",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T01:22:22.026879Z",
+     "iopub.status.busy": "2026-06-28T01:22:22.026707Z",
+     "iopub.status.idle": "2026-06-28T01:22:22.030094Z",
+     "shell.execute_reply": "2026-06-28T01:22:22.029774Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -171,7 +206,14 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "17a31f7c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T01:22:22.031409Z",
+     "iopub.status.busy": "2026-06-28T01:22:22.031249Z",
+     "iopub.status.idle": "2026-06-28T01:22:22.034402Z",
+     "shell.execute_reply": "2026-06-28T01:22:22.034030Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -200,7 +242,14 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "e5d062f3",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T01:22:22.035674Z",
+     "iopub.status.busy": "2026-06-28T01:22:22.035517Z",
+     "iopub.status.idle": "2026-06-28T01:22:22.038564Z",
+     "shell.execute_reply": "2026-06-28T01:22:22.038226Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -229,7 +278,14 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "9f627c6a",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T01:22:22.040098Z",
+     "iopub.status.busy": "2026-06-28T01:22:22.039928Z",
+     "iopub.status.idle": "2026-06-28T01:22:22.043698Z",
+     "shell.execute_reply": "2026-06-28T01:22:22.043324Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -250,7 +306,14 @@
    "cell_type": "code",
    "execution_count": 9,
    "id": "dae06b1f",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T01:22:22.044953Z",
+     "iopub.status.busy": "2026-06-28T01:22:22.044790Z",
+     "iopub.status.idle": "2026-06-28T01:22:22.047959Z",
+     "shell.execute_reply": "2026-06-28T01:22:22.047662Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -271,7 +334,14 @@
    "cell_type": "code",
    "execution_count": 10,
    "id": "fc2e39cd",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T01:22:22.049187Z",
+     "iopub.status.busy": "2026-06-28T01:22:22.049038Z",
+     "iopub.status.idle": "2026-06-28T01:22:22.052237Z",
+     "shell.execute_reply": "2026-06-28T01:22:22.051901Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -308,7 +378,14 @@
    "cell_type": "code",
    "execution_count": 11,
    "id": "d8060be7",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T01:22:22.053729Z",
+     "iopub.status.busy": "2026-06-28T01:22:22.053583Z",
+     "iopub.status.idle": "2026-06-28T01:22:22.056325Z",
+     "shell.execute_reply": "2026-06-28T01:22:22.056016Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -373,7 +450,14 @@
    "cell_type": "code",
    "execution_count": 12,
    "id": "3ac6c489",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T01:22:22.057685Z",
+     "iopub.status.busy": "2026-06-28T01:22:22.057528Z",
+     "iopub.status.idle": "2026-06-28T01:22:22.060112Z",
+     "shell.execute_reply": "2026-06-28T01:22:22.059812Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -410,7 +494,14 @@
    "cell_type": "code",
    "execution_count": 13,
    "id": "41b725fa",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T01:22:22.061326Z",
+     "iopub.status.busy": "2026-06-28T01:22:22.061172Z",
+     "iopub.status.idle": "2026-06-28T01:22:22.064202Z",
+     "shell.execute_reply": "2026-06-28T01:22:22.063891Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -441,7 +532,14 @@
    "cell_type": "code",
    "execution_count": 14,
    "id": "8fa26a99",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T01:22:22.065498Z",
+     "iopub.status.busy": "2026-06-28T01:22:22.065354Z",
+     "iopub.status.idle": "2026-06-28T01:22:22.067758Z",
+     "shell.execute_reply": "2026-06-28T01:22:22.067477Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -472,7 +570,14 @@
    "cell_type": "code",
    "execution_count": 15,
    "id": "9993e4e0",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T01:22:22.069090Z",
+     "iopub.status.busy": "2026-06-28T01:22:22.068941Z",
+     "iopub.status.idle": "2026-06-28T01:22:22.073914Z",
+     "shell.execute_reply": "2026-06-28T01:22:22.073573Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -516,7 +621,14 @@
    "cell_type": "code",
    "execution_count": 16,
    "id": "d647a6cb",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T01:22:22.075201Z",
+     "iopub.status.busy": "2026-06-28T01:22:22.075053Z",
+     "iopub.status.idle": "2026-06-28T01:22:22.077599Z",
+     "shell.execute_reply": "2026-06-28T01:22:22.077294Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -547,7 +659,14 @@
    "cell_type": "code",
    "execution_count": 17,
    "id": "ee627df2",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T01:22:22.078867Z",
+     "iopub.status.busy": "2026-06-28T01:22:22.078710Z",
+     "iopub.status.idle": "2026-06-28T01:22:22.081703Z",
+     "shell.execute_reply": "2026-06-28T01:22:22.081430Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -589,16 +708,16 @@
        " 'claims_surr_pp',\n",
        " 'comm_table',\n",
        " 'commissions',\n",
-       " 'disc_rate_mth',\n",
+       " 'commissions_init',\n",
+       " 'commissions_init_pp',\n",
+       " 'commissions_ren',\n",
+       " 'commissions_ren_pp',\n",
+       " 'disc_rate',\n",
        " 'expense_acq_pp',\n",
        " 'expense_maint_pp',\n",
        " 'expenses',\n",
        " 'exps_acq',\n",
        " 'exps_acq_total',\n",
-       " 'exps_comm_init',\n",
-       " 'exps_comm_init_pp',\n",
-       " 'exps_comm_ren',\n",
-       " 'exps_comm_ren_pp',\n",
        " 'exps_maint',\n",
        " 'exps_maint_total',\n",
        " 'exps_other',\n",
@@ -695,7 +814,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.13.9"
   }
  },
  "nbformat": 4,

--- a/lifelib/tests/libraries/test_tradlife_a_ex1.py
+++ b/lifelib/tests/libraries/test_tradlife_a_ex1.py
@@ -199,7 +199,7 @@ def test_risk_margin_equals_closed_form(ex1_model, idx):
     discount = 1.0
     expected = 0.0
     for s in range(proj.proj_len() + 1):
-        discount *= 1 + proj.disc_rate_mth(s)
+        discount *= 1 + proj.disc_rate(s)
         expected += proj.risk_life(s) / discount
     expected *= coc
     assert math.isclose(proj.risk_margin(0), expected, rel_tol=1e-9, abs_tol=1e-9)
@@ -211,7 +211,7 @@ def test_risk_margin_recursion(ex1_model, idx):
     proj = ex1_model.Projection[idx]
     coc = ex1_model.Assumptions.coc_rate()
     expected = (coc * proj.risk_life(0)
-                + proj.risk_margin(1)) / (1 + proj.disc_rate_mth(0))
+                + proj.risk_margin(1)) / (1 + proj.disc_rate(0))
     assert math.isclose(proj.risk_margin(0), expected, rel_tol=1e-9, abs_tol=1e-9)
 
 


### PR DESCRIPTION
## What

`disc_rate_mth` is a misnomer in the `annuallife` traditional-life models: the cell holds an **annual** discount rate, not a monthly one. This renames the cell and every reference to `disc_rate`.

## Scope

- **Models** — `TradLife_A`, `TradLife_A_EX1`, `TradLife_A_mx30` (`Economic`/`BaseProj`/`PV`, plus `risk_margin` in `TradLife_A_EX1.Projection`). Covers the cell definition, formula call sites, docstrings, `autosummary` entries, `:func:` cross-references, and the LaTeX math in `risk_margin`.
- **Docs** — `doc/source/libraries/annuallife/{Economic,BaseProj}.rst` `autofunction` directives.
- **Test** — `test_tradlife_a_ex1.py` risk-margin references.
- **Notebook** — `tradlife_a-space-overview.ipynb` re-executed against the renamed model (this also refreshes a few other previously-stale cell names, e.g. `exps_comm_* → commissions_*`).

Other libraries (`basiclife`, `savings`, …) also define a `disc_rate_mth` cell but are **out of scope** and left untouched.

## Verification

- **Behavioral equivalence** — captured key outputs (disc rates, `pv_net_cf`, `pv_premiums`/`pv_claims`/`pv_expenses`, `risk_life`, `risk_margin`) for idx 0/100/200 before vs. after; results are byte-identical for all three models.
- **Tests** — `test_tradlife_a.py` + `test_tradlife_a_ex1.py` = **65 passed**.
- No `disc_rate_mth` (plain or LaTeX-escaped) remains in any tracked annuallife source.

## Reviewer notes

- The notebook diff is large but is mostly re-execution noise (regenerated outputs, renumbered `execution_count`, metadata version bump); the only content change is `disc_rate_mth → disc_rate` plus the incidental refresh of already-stale names.
- `TradLife_A_mx30`'s `PV` keeps its own older `-claims_*` sign convention — only the disc-rate token changed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
