### PR TITLE
REF: Backport enhanced get_named_range_as_dict to TradLife_A and TradLife_A_mx30

### DIFF
--- a/doc/source/libraries/annuallife/TradLife_A_EX1/InputData.rst
+++ b/doc/source/libraries/annuallife/TradLife_A_EX1/InputData.rst
@@ -11,6 +11,4 @@ Cells Descriptions
 
 .. autofunction:: life_corr_data
 
-.. autofunction:: get_named_range_as_dict
-
 .. autofunction:: const_params

--- a/lifelib/libraries/annuallife/TradLife_A/InputData/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A/InputData/__init__.py
@@ -231,10 +231,12 @@ def scenarios():
 
 
 def get_named_range_as_dict(name):
-    """Read a two-column Excel named range as a :obj:`dict`.
+    """Read an Excel named range as a :obj:`dict`.
 
-    The first column of the range becomes the dict keys and the second
-    column becomes the values.
+    The right-most column of the range becomes the dict values.
+    If the range has exactly two columns, the first column becomes the
+    keys. If it has more than two columns, the keys are tuples of the
+    values of all columns except the right-most one.
     """
     wb = input_workbook()
 
@@ -243,7 +245,16 @@ def get_named_range_as_dict(name):
 
     rows = list(ws[cell_range.replace('$', '')])
 
-    return {row[0].value: row[1].value for row in rows}
+    result = {}
+    for row in rows:
+        *key_cells, value_cell = row
+        if len(key_cells) == 1:
+            key = key_cells[0].value
+        else:
+            key = tuple(cell.value for cell in key_cells)
+        result[key] = value_cell.value
+
+    return result
 
 
 _is_cached = False

--- a/lifelib/libraries/annuallife/TradLife_A_EX1/InputData/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_EX1/InputData/__init__.py
@@ -31,15 +31,11 @@ named range and returns the life-risk correlation matrix as a
 Updated Cells
 ^^^^^^^^^^^^^
 
-:func:`get_named_range_as_dict` is generalised to support named ranges
-with more than two columns: the right-most column holds the values and
-the remaining columns form a tuple key (used by :func:`life_shock_data`).
 :func:`const_params` now also exposes the new ``CoCRate``
 (cost-of-capital) parameter read from the ``ConstParams`` range.
 
 .. autosummary::
 
-   ~get_named_range_as_dict
    ~const_params
 
 """

--- a/lifelib/libraries/annuallife/TradLife_A_mx30/InputData/__init__.py
+++ b/lifelib/libraries/annuallife/TradLife_A_mx30/InputData/__init__.py
@@ -226,10 +226,12 @@ def scenarios():
 
 
 def get_named_range_as_dict(name):
-    """Read a two-column Excel named range as a :obj:`dict`.
+    """Read an Excel named range as a :obj:`dict`.
 
-    The first column of the range becomes the dict keys and the second
-    column becomes the values.
+    The right-most column of the range becomes the dict values.
+    If the range has exactly two columns, the first column becomes the
+    keys. If it has more than two columns, the keys are tuples of the
+    values of all columns except the right-most one.
     """
     wb = input_workbook()
 
@@ -238,7 +240,16 @@ def get_named_range_as_dict(name):
 
     rows = list(ws[cell_range.replace('$', '')])
 
-    return {row[0].value: row[1].value for row in rows}
+    result = {}
+    for row in rows:
+        *key_cells, value_cell = row
+        if len(key_cells) == 1:
+            key = key_cells[0].value
+        else:
+            key = tuple(cell.value for cell in key_cells)
+        result[key] = value_cell.value
+
+    return result
 
 
 _is_cached = False


### PR DESCRIPTION
## Summary

Backports the generalised `InputData.get_named_range_as_dict` from **TradLife_A_EX1** into **TradLife_A** and **TradLife_A_mx30**, and removes the now-redundant delta documentation for it from TradLife_A_EX1.

- **TradLife_A / TradLife_A_mx30** — `get_named_range_as_dict` now uses the right-most column as the value. A two-column range keeps scalar keys (unchanged behavior); a range with more than two columns builds a tuple key from all-but-last columns. The function source is now byte-identical across all three models.
- **TradLife_A_EX1** — since `get_named_range_as_dict` is no longer a delta from TradLife_A, it is dropped from the "Updated Cells" section of the `InputData` Space module docstring and from the matching `.. autofunction::` entry in `InputData.rst`. `const_params` remains the only updated cell.

## Verification

Loaded all three models in modelx 0.31.1 against the real `input.xlsx`:

- Backported function source is **byte-identical** across all three models.
- 2-column `ConstParams` → scalar keys on all three.
- 5-column `LifeShocks` → 4-tuple keys on all three (the multi-column path now works in TradLife_A / TradLife_A_mx30, which previously collapsed it to the first two columns).
- EX1's `life_shock_data()` still maps enum names to integer codes correctly, e.g. `(1, 0, 0, 0) → 0.15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)