### PR TITLE
DOC: Note TradLife_A_EX1 supersedes solvency2 and deprecate the library

### DIFF
--- a/doc/source/libraries/annuallife/index.rst
+++ b/doc/source/libraries/annuallife/index.rst
@@ -43,8 +43,8 @@ input data of :mod:`~annuallife.TradLife_A`; only the spaces that change
 are documented on its page. See :mod:`~annuallife.TradLife_A_EX1` for the
 list of updates from :mod:`~annuallife.TradLife_A`.
 
-Successor of simplelife
-^^^^^^^^^^^^^^^^^^^^^^^
+Successor of simplelife and solvency2
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The **annuallife** library is the updated successor of the legacy
 :ref:`project_simplelife` project. Compared with the original
@@ -62,6 +62,13 @@ The **annuallife** library is the updated successor of the legacy
 * **A renamed input space.** The space holding *input.xlsx*-backed
   References is now ``InputData`` and is referenced as ``input_data``
   by the rest of the model.
+
+Likewise, :mod:`~annuallife.TradLife_A_EX1` supersedes the legacy
+:ref:`project_solvency2` project. Both build a Solvency II life-risk SCR
+and risk-margin calculation as a reference for complex nested
+projections, but :mod:`~annuallife.TradLife_A_EX1` does so on top of the
+modernized :mod:`~annuallife.TradLife_A` model. The *solvency2* project
+is therefore deprecated and will be removed in a future release.
 
 How to Use the Library
 ------------------------------

--- a/doc/source/projects/solvency2.rst
+++ b/doc/source/projects/solvency2.rst
@@ -11,6 +11,12 @@ Project **solvency2**
 
 |modelx badge|
 
+.. warning::
+
+   :mod:`solvency2` has been superseded by
+   :mod:`~annuallife.TradLife_A_EX1` in the :mod:`annuallife` library,
+   and will be removed in a future release.
+
 **solvency2** is a project for building a model to
 calculate life risks of selected policies at various points in their policy periods
 based on Solvency II standard formula.


### PR DESCRIPTION
## Summary

The addition of `TradLife_A_EX1` to the **annuallife** library effectively deprecates the **solvency2** project, since both build a Solvency II life-risk SCR and risk-margin calculation as a reference for complex nested projections — but `TradLife_A_EX1` does so on top of the modernized `TradLife_A` model.

This PR documents that relationship:

- **annuallife** library page: renamed the *Successor of simplelife* subsection to *Successor of simplelife and solvency2*, and added a paragraph explaining that `TradLife_A_EX1` supersedes the legacy `solvency2` project, which is now deprecated.
- **solvency2** project page: added a `.. warning::` deprecation admonition (mirroring the one on the **simplelife** page) noting the model is superseded by `TradLife_A_EX1` in the **annuallife** library.

## Verification

- Test-built the docs with Sphinx 8.2.3. Build succeeds; all cross-references (`:ref:project_solvency2`, `:mod:annuallife`, `:mod:~annuallife.TradLife_A_EX1`) resolve to real internal anchors in the rendered HTML.
- No new build warnings introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)