### PR TITLE
DOC: Hide outdated devguide/index in a hidden toctree

### DIFF
--- a/doc/source/libraries/index.rst
+++ b/doc/source/libraries/index.rst
@@ -59,4 +59,9 @@ were developed using an older cashflow model. All the projects use modelx.
    ../projects/ifrs17sim
    ../projects/solvency2
    ../projects/smithwilson
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
    ../projects/devguide/index


### PR DESCRIPTION
## Summary

Move `../projects/devguide/index` out of the visible **Past Libraries** toctree in `doc/source/libraries/index.rst` into a separate `:hidden:` toctree on the same page.

The `devguide/index` link is outdated. Hiding it removes it from the reader-visible list while keeping the page in Sphinx's doc tree, so it still renders (no orphan/toctree warnings) and remains available for a future update.

## Changes

- `doc/source/libraries/index.rst`: split `../projects/devguide/index` into a new `.. toctree:: :hidden:` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)