### PR TITLE
Prepare lifelib v0.13.0 release

### DIFF
--- a/doc/source/libraries/index.rst
+++ b/doc/source/libraries/index.rst
@@ -59,9 +59,3 @@ were developed using an older cashflow model. All the projects use modelx.
    ../projects/ifrs17sim
    ../projects/solvency2
    ../projects/smithwilson
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   ../projects/devguide/index

--- a/doc/source/projects/devguide/index.rst
+++ b/doc/source/projects/devguide/index.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Development Guide
 =================
 

--- a/doc/source/releases/relnotes_v0.13.rst
+++ b/doc/source/releases/relnotes_v0.13.rst
@@ -1,0 +1,86 @@
+.. currentmodule:: lifelib.libraries
+
+==================================
+lifelib v0.13 Releases
+==================================
+
+To update lifelib, run the following command::
+
+    >>> pip install lifelib --upgrade
+
+If you're using Anaconda, use the ``conda`` command instead::
+
+    >>> conda update lifelib
+
+
+.. _relnotes_v0.13.0:
+
+lifelib v0.13.0 (28 June 2026)
+==================================
+
+New Model
+----------------
+
+This release adds a new model, :mod:`~annuallife.TradLife_A_EX1`, to the
+:mod:`~annuallife` library. :mod:`~annuallife.TradLife_A_EX1` is a
+nested-projection example derived from :mod:`~annuallife.TradLife_A`
+that demonstrates how to build a Solvency II Life capital calculation
+at each projection step. Each nested valuation is modelled by
+``Projection.InnerProj[t0, risk, shock]``, which re-runs the policy
+projection from the valuation time ``t0`` under a stressed assumption set.
+
+The model applies the prescribed Solvency II life sub-risk shocks
+(lapse up, down and mass, mortality, longevity and expense) inside the
+inner projection, computes the loss in the value of in-force under each
+shock as ``risk_life_sub(t, risk)``, aggregates the sub-risks into the
+life SCR ``risk_life(t)`` using the prescribed correlation matrix, and
+derives the cost-of-capital ``risk_margin(t)``. Example plot scripts for the SCR
+cashflows, the life-risk radar charts and the lapse-up in-force run-off
+are included.
+
+:mod:`~annuallife.TradLife_A_EX1` supersedes the legacy :mod:`~solvency2`
+project, which is now deprecated.
+
+Changes
+------------
+
+* lifelib now requires Python 3.9 or newer. The packaging metadata in
+  ``setup.py`` and ``pyproject.toml`` is reconciled to drop Python 3.7
+  and 3.8 and add Python 3.14 (``requires-python >= 3.9``), enforcing at
+  install time the support policy first announced in v0.12.0.
+
+* ``disc_rate_mth`` is renamed to ``disc_rate`` across the
+  :mod:`~annuallife` traditional-life models
+  (:mod:`~annuallife.TradLife_A`, ``TradLife_A_EX1`` and
+  ``TradLife_A_mx30``). The cell holds an annual discount rate, so the
+  ``_mth`` suffix was a misnomer. Numerical results are unchanged.
+
+* In :mod:`~annuallife.TradLife_A`, the present-value outflow cells in
+  the ``PV`` Space (claims, expenses and commissions) now return their
+  present values as positive amounts, and ``pv_net_cf`` subtracts them
+  from ``pv_premiums``. The value of ``pv_net_cf`` is unchanged.
+
+* ``InputData.get_named_range_as_dict`` is generalised to support named
+  ranges with more than two columns, building a tuple key from the
+  left-hand columns and taking the right-most column as the value
+  (two-column ranges keep scalar keys as before). The enhancement is
+  applied across :mod:`~annuallife.TradLife_A`, ``TradLife_A_EX1`` and
+  ``TradLife_A_mx30``.
+
+* The :mod:`~solvency2` project is deprecated and superseded by
+  :mod:`~annuallife.TradLife_A_EX1`. A deprecation notice is added to the
+  affected page.
+
+* The documentation for :mod:`~annuallife.TradLife_A` is substantially
+  expanded, including per-Space docstrings, actuarial formulas for
+  ``net_prem_rate`` and ``reserve_nlp_rate``, an Input File reference with
+  per-named-range subsections, and additional model-structure diagrams.
+
+Fixes
+------------
+
+* ``inflation_factor`` in the :mod:`~annuallife` models
+  (:mod:`~annuallife.TradLife_A` and ``TradLife_A_mx30``) now compounds
+  upward as ``(1 + rate) ** t`` instead of dividing by ``(1 + rate)``,
+  matching its docstring. The shipped input has ``InflRate = 0``, so
+  existing results are numerically unchanged.

--- a/doc/source/updates.rst
+++ b/doc/source/updates.rst
@@ -14,6 +14,12 @@ Updates
     Follow <a href="https://www.linkedin.com/company/lifelib" target="_blank">lifelib on LinkedIn</a>
     for more frequent updates.</p>
 
+* *28 June 2026:*
+  lifelib :ref:`v0.13.0<relnotes_v0.13.0>` is released.
+  :mod:`~annuallife.TradLife_A_EX1`, a new nested-projection example that
+  demonstrates a Solvency II Life capital calculation, is added to
+  :mod:`~annuallife`. The :mod:`~solvency2` project is now deprecated.
+
 * *17 May 2026:*
   lifelib :ref:`v0.12.0<relnotes_v0.12.0>` is released.
   :mod:`~annuallife`, a new library featuring the

--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -33,6 +33,7 @@ Documentation for released versions of lifelib is available under
 .. toctree::
    :maxdepth: 1
 
+   releases/relnotes_v0.13
    releases/relnotes_v0.12
    releases/relnotes_v0.11
    releases/relnotes_v0.10

--- a/lifelib/__init__.py
+++ b/lifelib/__init__.py
@@ -1,7 +1,7 @@
 import os.path
 from lifelib.commands.create import create
 
-VERSION = (0, 12, 0)
+VERSION = (0, 13, 0)
 __version__ = '.'.join([str(x) for x in VERSION])
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "lifelib"
 dynamic = ["version"]
 description = "Actuarial models in Python"
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 license = {text = "MIT License"}
 authors = [
     {name = "lifelib Developers", email = "admin@lifelib.io"}
@@ -25,8 +25,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -95,7 +93,7 @@ markers = [
 
 [tool.black]
 line-length = 88
-target-version = ['py37', 'py38', 'py39', 'py310', 'py311', 'py312', 'py313', 'py314']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313', 'py314']
 include = '\.pyi?$'
 extend-exclude = '''
 /(

--- a/setup.py
+++ b/setup.py
@@ -156,13 +156,12 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13'
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14'
     ],
 
     # What does your project relate to?
@@ -187,7 +186,7 @@ setup(
     #  specifier string will prevent pip from installing the project on
     # other Python versions.
     # For example, if your package is for Python 3+ only, write:
-    python_requires='>=3.7',
+    python_requires='>=3.9',
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Prepares the **v0.13.0** release. Four focused commits on top of `v0.12.0`:

1. **`df57342` DOC: Hide devguide from the sidebar by marking it `:orphan:`**
   The earlier change moved `projects/devguide/index` into a `:hidden:` toctree, but hidden toctrees are still included in the left sidebar by default, so the outdated *Development Guide* link kept showing there. The page is now `:orphan:` and the empty hidden toctree is removed — the page still builds (and stays reachable from the home-page card) but no longer appears in the sidebar.

2. **`f2dcaec` MAINT: Drop Python 3.7/3.8 support, require Python >= 3.9**
   Reconciles `setup.py` and `pyproject.toml` with the support policy announced in the v0.12.0 notes: `requires-python`/`python_requires` → `>=3.9`, drop the 3.7/3.8 classifiers, add the missing 3.14 classifier in `setup.py`, and trim the black `target-version` list. v0.13.0 is the first release that actually enforces the 3.9 floor at install time.

3. **`67c3d39` DOC: Add v0.13.0 release notes** (dated 28 June 2026)
   New `doc/source/releases/relnotes_v0.13.rst`, wired into the toctree in `whatsnew.rst`, plus an `updates.rst` entry.

4. **`6ec1350` DIST: Release v0.13.0**
   Bumps `VERSION` to `(0, 13, 0)`. Copyright years in `README.rst`/`conf.py` are already 2026, so no further changes were needed.

## Headline change

The release notes are headlined by the new **`annuallife.TradLife_A_EX1`** model — a nested-projection example derived from `TradLife_A` that demonstrates a Solvency II Life capital (SCR) calculation at each projection step via `InnerProj[t0, risk, shock]` (life sub-risk shocks, `risk_life_sub`/`risk_life`/`risk_margin` cells, and SCR-cashflow / life-risk-radar / lapse-up-run-off plot scripts). It supersedes the now-deprecated `solvency2` project. Also included: the `disc_rate_mth`→`disc_rate` rename, the `TradLife_A` PV-outflow sign convention change, the generalized `get_named_range_as_dict`, and the `inflation_factor` compounding fix.

## Reviewer notes

- **Verified under the `py313` env:** 65 annuallife/TradLife tests pass; `import lifelib` → `0.13.0`; `setup.py` parses the version.
- **Docs build** (HTML) succeeds with no new toctree/orphan warnings; confirmed `devguide` is gone from the Libraries sidebar while the full library/project navigation remains intact.
- **Release-notes accuracy/completeness** were cross-checked against the `v0.12.0..HEAD` diff.
- The `inflation_factor` fix and `disc_rate` rename are numerically neutral (shipped input has `InflRate = 0`; the rename is pure).
- Not pushed as a tag — `v0.13.0` is intended to be cut from `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)