### PR TITLE
DOC: Update download page for WPy64-31450-20260809

### DIFF
--- a/doc/source/download.rst
+++ b/doc/source/download.rst
@@ -8,7 +8,7 @@ Download lifelib with WinPython.
 
 .. raw:: html
 
-    <a class="btn btn-primary btn-lg" href="https://drive.google.com/u/0/uc?export=download&id=1OsfXa_BjgJMG8Okfc0E22pk8Ldj_C8Vk" role="button">Download</a>
+    <a class="btn btn-primary btn-lg" href="https://drive.google.com/u/0/uc?export=download&id=1z9krAvl23VpwRyCOH0N5JGNiTp3UOscO" role="button">Download</a>
 
 :ref:`Install manually <installation>` if you're a Linux or Mac user.
 
@@ -16,10 +16,43 @@ Download lifelib with WinPython.
 File Information
 ================
 
-Latest release (10 Aug 2025)
-------------------------------
+Latest release (9 Aug 2026)
+---------------------------
 
-:Downloadable: WPy64-31350-20250810.zip
+:Downloadable: WPy64-31450-20260809.zip
+
+:Base Python Distribution:
+    WinPython64-3.14.5.0slim
+
+    (Python 3.14.5 + Spyder 6.1.4)
+
+:Additional Packages:
+    openpyxl 3.1.5
+
+    numpy-financial 1.0.0
+
+    modelx 0.32.0 *(Updated)*
+
+    spyder-modelx 0.15.2 *(Updated)*
+
+    spymx-kernels 0.4.0 *(Updated)*
+
+    modelx-cython 0.0.9 *(Updated)*
+
+    lifelib 0.13.0 *(Updated)*
+
+    QuantLib 1.43 *(Updated)*
+
+    Cython 3.2.4 *(Updated)*
+
+
+Past releases
+-------------
+
+10 Aug 2025
+^^^^^^^^^^^
+
+:Downloadable: `WPy64-31350-20250810.zip`_
 
 :Base Python Distribution:
     WinPython64-3.13.5.0slim
@@ -43,9 +76,7 @@ Latest release (10 Aug 2025)
 
     QuantLib 1.39 *(Updated)*
 
-
-Past releases
--------------
+.. _WPy64-31350-20250810.zip: https://drive.google.com/u/0/uc?export=download&id=1OsfXa_BjgJMG8Okfc0E22pk8Ldj_C8Vk
 
 13 May 2023
 ^^^^^^^^^^^


### PR DESCRIPTION
## What changed

Updates `doc/source/download.rst` for the new WinPython bundle:

- **Download button** now points at the new Google Drive id `1z9krAvl23VpwRyCOH0N5JGNiTp3UOscO`.
- **New latest release** section for `WPy64-31450-20260809.zip` — WinPython64-3.14.5.0slim (Python 3.14.5 + Spyder 6.1.4), with modelx 0.32.0, spyder-modelx 0.15.2, spymx-kernels 0.4.0, modelx-cython 0.0.9, lifelib 0.13.0, QuantLib 1.43 and Cython 3.2.4.
- **Previous release (10 Aug 2025)** moved to the top of *Past releases*, converted to the linked form used by the other past entries, with its target keeping the old id `1OsfXa_BjgJMG8Okfc0E22pk8Ldj_C8Vk`.

## Notes for the reviewer

- The heading date **9 Aug 2026** was derived from the `20260809` in the zip name, matching how every past entry's heading tracks its file date. Change it if the intended release date differs.
- `Cython 3.2.4` is marked *(Updated)* as supplied, although Cython was not listed in the previous release entry — *(New)* may be more accurate.
- Docs build verified: `python -m sphinx -M html source build` succeeds, and the 15 warnings are all pre-existing (`economic_curves` autosummary import-cycle notices, `sphinx_gallery_conf` cache warning). The new past-release link target resolves with no reference warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)