### PR TITLE
DIST: Release v0.14.0

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -115,6 +115,7 @@ Contribute your excellent work to lifelib and share it with actuaries from all a
       * :doc:`libraries/annuallife/index`
       * :doc:`libraries/basiclife/index`
       * :doc:`libraries/savings/index`
+      * :doc:`libraries/uslib/index`
       * :doc:`libraries/appliedlife/index`
       * :doc:`libraries/assets/index`
       * :doc:`libraries/ifrs17a/index`

--- a/doc/source/releases/relnotes_v0.14.rst
+++ b/doc/source/releases/relnotes_v0.14.rst
@@ -1,0 +1,91 @@
+.. currentmodule:: lifelib.libraries
+
+==================================
+lifelib v0.14 Releases
+==================================
+
+To update lifelib, run the following command::
+
+    >>> pip install lifelib --upgrade
+
+If you're using Anaconda, use the ``conda`` command instead::
+
+    >>> conda update lifelib
+
+
+.. _relnotes_v0.14.0:
+
+lifelib v0.14.0 (17 August 2026)
+==================================
+
+New Library
+----------------
+
+This release adds a new library, :mod:`~uslib`.
+:mod:`~uslib` packages twelve reference liability cash flow projection
+models for the individual life insurance and annuity products sold in
+the United States, and, for each model, the product specification and
+technical notes it was built from.
+See the :mod:`~uslib` page for more details.
+
+The six life models are ``Term_US_A`` (level premium term),
+``WholeLife_US_A`` (participating whole life), ``UL_US_S`` (universal
+life), ``IUL_US_S`` (indexed UL), ``VUL_US_S`` (variable UL) and
+``ULSG_US_S`` (guaranteed UL). The six annuity models are ``MYGA_US_S``
+(fixed deferred), ``FIA_US_S`` (fixed indexed), ``VA_US_S`` (variable),
+``RILA_US_S`` (registered index-linked), ``SPIA_US_S`` (immediate) and
+``DIA_US_S`` (deferred income). The grid letters follow lifelib's own
+model names: ``_A`` marks an annual projection step, as in
+:mod:`~annuallife.TradLife_A`, and ``_S`` a monthly one, as in
+:mod:`~basiclife.BasicTerm_S`. ``S`` also carries its other lifelib
+sense, scalar rather than vectorized, and all twelve models project
+one model point at a time.
+
+Each model projects one product's gross liability cash flows, such as
+premiums, claims, surrenders, withdrawals, expenses and commissions,
+on the product's own processing order and timing. None of the models
+discounts, so discounting, reserving and capital are left to a layer
+that consumes the cash flows. Every model has the same two Spaces:
+``Data``, which reads the input files, and ``Projection``, which is
+parameterized by ``point_id``. The inputs are CSV files kept outside
+the model folder so that they can be edited or swapped in place.
+
+Beside each model sit the documents it was built from:
+``product-spec.md``, a representative product specification composed
+from publicly available documentation of real products;
+``technical-notes.md``, the liability cash flow model on paper, with
+state variables, recursions, processing order and a numeric worked
+example; ``model.md``, how the model implements those notes; and
+``sources.md``, every source cited. The tests ship inside the library
+and run against your own copy: each model reproduces the worked example
+in its technical notes, and ``tests/test_model_conventions.py`` asserts
+the shared model structure and Cells names across all twelve models.
+
+.. warning::
+
+   :mod:`~uslib` is in its draft stage, and its contents are subject to
+   change as development continues.
+
+.. warning::
+
+   The :mod:`~uslib` models are mechanics demonstrations, not pricing or
+   reserving results. The contractual elements are sourced, but most
+   behavioural and expense assumptions are standardizations introduced
+   for the reference implementation, because no public source carries
+   them, and current non-guaranteed scales, such as declared crediting
+   rates, current cost of insurance and indexed UL caps, are not public
+   at all. Replace them with company data before drawing any conclusion
+   from the numbers.
+
+Changes
+------------
+
+* lifelib now requires ``modelx`` v0.32.0 or newer, because the
+  :mod:`~uslib` models are saved in the modelx serializer version 8
+  format introduced in modelx v0.32.0. Earlier versions of ``modelx``
+  cannot read them. The requirement is declared in both ``setup.py``
+  and ``pyproject.toml``.
+
+* Markdown files are now packaged with lifelib, so the documents that
+  accompany the :mod:`~uslib` models are installed with lifelib and
+  copied into your project by ``lifelib.create``.

--- a/doc/source/updates.rst
+++ b/doc/source/updates.rst
@@ -14,6 +14,15 @@ Updates
     Follow <a href="https://www.linkedin.com/company/lifelib" target="_blank">lifelib on LinkedIn</a>
     for more frequent updates.</p>
 
+* *17 August 2026:*
+  lifelib :ref:`v0.14.0<relnotes_v0.14.0>` is released.
+  :mod:`~uslib`, a new library of twelve reference liability cash flow
+  projection models for U.S. individual life and annuity products, is
+  added. The library is in its draft stage.
+
+* *9 Aug 2026:*
+  New download available on the :doc:`download` page.
+
 * *28 June 2026:*
   lifelib :ref:`v0.13.0<relnotes_v0.13.0>` is released.
   :mod:`~annuallife.TradLife_A_EX1`, a new nested-projection example that

--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -33,6 +33,7 @@ Documentation for released versions of lifelib is available under
 .. toctree::
    :maxdepth: 1
 
+   releases/relnotes_v0.14
    releases/relnotes_v0.13
    releases/relnotes_v0.12
    releases/relnotes_v0.11

--- a/lifelib/__init__.py
+++ b/lifelib/__init__.py
@@ -1,7 +1,7 @@
 import os.path
 from lifelib.commands.create import create
 
-VERSION = (0, 13, 0)
+VERSION = (0, 14, 0)
 __version__ = '.'.join([str(x) for x in VERSION])
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "modelx>=0.31.0",
+    "modelx>=0.32",
 ]
 
 [project.urls]


### PR DESCRIPTION
Release preparation for lifelib v0.14.0.

## Documentation

- Add `doc/source/releases/relnotes_v0.14.rst`, covering the new **uslib** library (twelve reference liability cash flow projection models for U.S. individual life and annuity products, each shipping with the product specification and technical notes it was built from), the modelx v0.32.0 requirement, and the Markdown packaging change. The notes carry uslib's own two caveats — the library is in its draft stage, and the models are mechanics demonstrations rather than pricing or reserving results.
- Wire the file into the release-notes toctree in `whatsnew.rst`.
- Add `updates.rst` entries for the release and for the 9 Aug 2026 WinPython download, which had no entry yet.
- List uslib on the landing-page `Libraries` card in `index.rst`. It was missing there after the uslib merge, so the landing page did not list the library this release announces.

## Version and packaging

- Bump `VERSION` to `(0, 14, 0)`.
- Reconcile `pyproject.toml`'s `dependencies` with `setup.py`'s `install_requires` at `modelx>=0.32`. Under setuptools >= 61 the pyproject table overwrites `install_requires`, so without this the wheel would still declare `modelx>=0.31.0` — under which all twelve uslib models fail to deserialize, since they are saved in serializer version 8, introduced in modelx 0.32.0.

The copyright years in `README.rst` and `conf.py` are already 2026, so no further changes are needed for a 2026 release.

## Verification

`sphinx-build -b html` succeeds with 15 warnings, all pre-existing (`autosummary.import_cycle` in economic_curves, `config.cache` unpickleable values) and none from the new or changed pages. Every `:mod:` cross-reference in the new release notes resolves. The built site title reads `lifelib 0.14.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)