### PR TITLE
DIST: Release v0.15.0

### DIFF
--- a/doc/source/releases/relnotes_v0.15.rst
+++ b/doc/source/releases/relnotes_v0.15.rst
@@ -1,0 +1,94 @@
+.. currentmodule:: lifelib.libraries
+
+==================================
+lifelib v0.15 Releases
+==================================
+
+To update lifelib, run the following command::
+
+    >>> pip install lifelib --upgrade
+
+If you're using Anaconda, use the ``conda`` command instead::
+
+    >>> conda update lifelib
+
+
+.. _relnotes_v0.15.0:
+
+lifelib v0.15.0 (22 August 2026)
+==================================
+
+New Library
+----------------
+
+This release adds a new library, :mod:`~uklib`.
+:mod:`~uklib` packages seven reference liability cash flow projection
+models for the individual life insurance products sold in the United
+Kingdom, plus the pension annuity, and, for each model, the product
+specification and technical notes it was built from.
+See the :mod:`~uklib` page for more details.
+
+The four protection models are ``Term_UK_A`` (guaranteed-premium term
+assurance), ``CI_UK_S`` (critical illness cover), ``IP_UK_S`` (income
+protection) and ``WOL_UK_S`` (whole of life). The two savings models
+are ``WP_UK_A`` (with-profits) and ``ULB_UK_S`` (unit-linked investment
+bond), and ``PA_UK_S`` is the pension annuity. The grid letters follow
+the same convention as :mod:`~uslib`: ``_A`` marks an annual projection
+step and ``_S`` a monthly one, and all seven models project one model
+point at a time.
+
+The pension annuity is in the library because annuities are the
+dominant liability of UK life insurers and the centrepiece of the
+Solvency UK matching adjustment. The coverage otherwise differs in kind
+from :mod:`~uslib`'s, because the UK retail deferred annuity market is
+negligible, while the pension annuity bought with a pension pot is the
+product that matters.
+
+:mod:`~uklib` is shaped exactly like :mod:`~uslib`. Each model projects
+one product's gross liability cash flows, such as premiums, claims,
+surrenders, expenses and commission, on the product's own processing
+order and timing. None of the models discounts, so discounting,
+reserving and capital are left to a layer that consumes the cash flows.
+Every model has the same two Spaces: ``Data``, which reads the input
+files, and ``Projection``, which is parameterized by ``point_id``. The
+inputs are CSV files kept outside the model folder so that they can be
+edited or swapped in place.
+
+Beside each model sit the documents it was built from:
+``product-spec.md``, a representative product specification composed
+from publicly available documentation of real products;
+``technical-notes.md``, the liability cash flow model on paper, with
+state variables, recursions, processing order and a numeric worked
+example; ``model.md``, how the model implements those notes; and
+``sources.md``, every source cited. The tests ship inside the library
+and run against your own copy: each model reproduces the worked example
+in its technical notes, and ``tests/test_model_conventions_uk.py``
+asserts the shared model structure and Cells names across all seven
+models.
+
+.. warning::
+
+   :mod:`~uklib` is in its draft stage, and its contents are subject to
+   change as development continues.
+
+.. warning::
+
+   The :mod:`~uklib` models are mechanics demonstrations, not pricing or
+   reserving results. The contractual elements are sourced, but every
+   decrement basis shipped with the library is a standardization
+   introduced for the reference implementation, because the CMI tables
+   that a UK insurer would actually use are restricted to Authorised
+   Users and cannot be redistributed. Nor is there any public premium
+   rate card, because UK protection and annuity pricing is quote-driven.
+   Replace both with company data before drawing any conclusion from the
+   numbers.
+
+Changes
+------------
+
+* The documents and docstrings in :mod:`~uslib` are updated. Product
+  sources are now cited by source tag in the published documents, with
+  the source details kept in ``sources.md``. Specification citations of
+  the form ``[S1]`` are now plain bracketed text rather than links,
+  which is the citation convention :mod:`~uklib` also follows. None of
+  the :mod:`~uslib` models behaves differently.

--- a/doc/source/updates.rst
+++ b/doc/source/updates.rst
@@ -14,6 +14,12 @@ Updates
     Follow <a href="https://www.linkedin.com/company/lifelib" target="_blank">lifelib on LinkedIn</a>
     for more frequent updates.</p>
 
+* *22 August 2026:*
+  lifelib :ref:`v0.15.0<relnotes_v0.15.0>` is released.
+  :mod:`~uklib`, a new library of seven reference liability cash flow
+  projection models for UK individual life products and the pension
+  annuity, is added. The library is in its draft stage.
+
 * *17 August 2026:*
   lifelib :ref:`v0.14.0<relnotes_v0.14.0>` is released.
   :mod:`~uslib`, a new library of twelve reference liability cash flow

--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -33,6 +33,7 @@ Documentation for released versions of lifelib is available under
 .. toctree::
    :maxdepth: 1
 
+   releases/relnotes_v0.15
    releases/relnotes_v0.14
    releases/relnotes_v0.13
    releases/relnotes_v0.12

--- a/lifelib/__init__.py
+++ b/lifelib/__init__.py
@@ -1,7 +1,7 @@
 import os.path
 from lifelib.commands.create import create
 
-VERSION = (0, 14, 0)
+VERSION = (0, 15, 0)
 __version__ = '.'.join([str(x) for x in VERSION])
 
 


### PR DESCRIPTION
Release paperwork for lifelib v0.15.0.

The release itself is `uklib` — seven UK life and pension annuity reference models — plus the `uslib` document and docstring update, both of which landed in #162. This branch adds only the notes and the version bump.

| File | Change |
|---|---|
| `doc/source/releases/relnotes_v0.15.rst` | New. The v0.15.0 notes, dated 22 August 2026 |
| `doc/source/whatsnew.rst` | `releases/relnotes_v0.15` at the top of the toctree |
| `doc/source/updates.rst` | Dated bullet inside the Latest Updates block |
| `lifelib/__init__.py` | `VERSION = (0, 15, 0)` |

**No dependency bump.** `uklib`'s models are saved in serializer version 8 under modelx 0.32.0, which the existing `modelx>=0.32` requirement in both `setup.py` and `pyproject.toml` already covers.

**No further doc wiring.** All three `uklib` wiring points — the table row and toctree entry in `doc/source/libraries/index.rst`, and the Libraries grid-item-card bullet in `doc/source/index.rst` — were already done in the merge commit.

Verified: `lifelib.__version__` reads `0.15.0` and the built pages title as `lifelib 0.15.0`. The docs build to 15 warnings, all pre-existing `autosummary.import_cycle` in `economic_curves` and the `config.cache` one, with none naming the release files. The new page renders, both `:mod:` links resolve, and the `:ref:` from `updates.rst` lands on the notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
